### PR TITLE
Fix Resolve request format

### DIFF
--- a/Sources/KonfidensProvider/KonfidensBatchFeatureProvider.swift
+++ b/Sources/KonfidensProvider/KonfidensBatchFeatureProvider.swift
@@ -301,7 +301,7 @@ extension KonfidensBatchFeatureProvider {
 
         /// Creates the `KonfidensBatchFeatureProvider` according to the settings specified in the builder.
         public func build() -> KonfidensBatchFeatureProvider {
-            let client = RemoteKonfidensClient(options: options, session: self.session, sendApplyEvent: false)
+            let client = RemoteKonfidensClient(options: options, session: self.session, applyOnResolve: false)
             let resolver = LocalStorageResolver(cache: cache)
             return KonfidensBatchFeatureProvider(
                 resolver: resolver, client: client, cache: cache, overrides: localOverrides, applyQueue: applyQueue)

--- a/Sources/KonfidensProvider/KonfidensClient/RemoteKonfidensClient.swift
+++ b/Sources/KonfidensProvider/KonfidensClient/RemoteKonfidensClient.swift
@@ -10,9 +10,9 @@ public class RemoteKonfidensClient: KonfidensClient {
     private var options: KonfidensClientOptions
 
     private var httpClient: HttpClient
-    private var sendApplyEvent: Bool
+    private var applyOnResolve: Bool
 
-    init(options: KonfidensClientOptions, session: URLSession? = nil, sendApplyEvent: Bool) {
+    init(options: KonfidensClientOptions, session: URLSession? = nil, applyOnResolve: Bool) {
         self.options = options
         self.baseUrl = "https://resolver.\(options.region.rawValue).\(domain)"
         if let session = session {
@@ -20,7 +20,7 @@ public class RemoteKonfidensClient: KonfidensClient {
         } else {
             self.httpClient = HttpClient()
         }
-        self.sendApplyEvent = sendApplyEvent
+        self.applyOnResolve = applyOnResolve
     }
 
     public func resolve(flag: String, ctx: EvaluationContext) throws -> ResolveResult {
@@ -28,7 +28,7 @@ public class RemoteKonfidensClient: KonfidensClient {
             flag: "flags/\(flag)",
             evaluationContext: try getEvaluationContextStruct(ctx: ctx),
             clientSecret: options.credentials.getSecret(),
-            sendApplyEvent: sendApplyEvent)
+            apply: applyOnResolve)
         guard let url = URL(string: "\(self.baseUrl)\(self.resolveRoute)/\(flag):resolve") else {
             throw KonfidensError.internalError(message: "Could not create service url")
         }
@@ -58,7 +58,7 @@ public class RemoteKonfidensClient: KonfidensClient {
         let request = BatchResolveFlagRequest(
             evaluationContext: try getEvaluationContextStruct(ctx: ctx),
             clientSecret: options.credentials.getSecret(),
-            sendApplyEvent: sendApplyEvent)
+            apply: applyOnResolve)
         guard let url = URL(string: "\(self.baseUrl)\(self.resolveRoute):batchResolve") else {
             throw KonfidensError.internalError(message: "Could not create service url")
         }
@@ -114,7 +114,7 @@ public class RemoteKonfidensClient: KonfidensClient {
                 value: nil,
                 contextHash: ctx.hash(),
                 flag: try displayName(resolvedFlag: resolvedFlag),
-                applyStatus: sendApplyEvent ? .applied : .notApplied)
+                applyStatus: applyOnResolve ? .applied : .notApplied)
         }
 
         let value = try TypeMapper.from(object: responseValue, schema: responseFlagSchema)
@@ -125,7 +125,7 @@ public class RemoteKonfidensClient: KonfidensClient {
             value: value,
             contextHash: ctx.hash(),
             flag: try displayName(resolvedFlag: resolvedFlag),
-            applyStatus: sendApplyEvent ? .applied : .notApplied)
+            applyStatus: applyOnResolve ? .applied : .notApplied)
     }
 
     private func getEvaluationContextStruct(ctx: EvaluationContext) throws -> Struct {
@@ -166,7 +166,7 @@ extension RemoteKonfidensClient {
         var flag: String
         var evaluationContext: Struct
         var clientSecret: String
-        var sendApplyEvent: Bool
+        var apply: Bool
     }
 
     struct ResolveFlagResponse: Codable {
@@ -209,7 +209,7 @@ extension RemoteKonfidensClient {
     struct BatchResolveFlagRequest: Codable {
         var evaluationContext: Struct
         var clientSecret: String
-        var sendApplyEvent: Bool
+        var apply: Bool
     }
 
     struct BatchResolveFlagResponse: Codable {

--- a/Sources/KonfidensProvider/KonfidensFeatureProvider.swift
+++ b/Sources/KonfidensProvider/KonfidensFeatureProvider.swift
@@ -166,7 +166,7 @@ extension KonfidensFeatureProvider {
 
         /// Creates the `KonfidensFeatureProvider` according to the settings specified in the builder.
         public func build() -> KonfidensFeatureProvider {
-            let client = RemoteKonfidensClient(options: options, session: self.session, sendApplyEvent: true)
+            let client = RemoteKonfidensClient(options: options, session: self.session, applyOnResolve: true)
             return KonfidensFeatureProvider(resolver: client, overrides: self.localOverrides)
         }
     }

--- a/Tests/KonfidensProviderTests/RemoteKonfidensClientTest.swift
+++ b/Tests/KonfidensProviderTests/RemoteKonfidensClientTest.swift
@@ -26,7 +26,7 @@ class RemoteKonfidensClientTest: XCTestCase {
         let session = MockedKonfidensClientURLProtocol.mockedSession(flags: flags)
 
         let client = RemoteKonfidensClient(
-            options: .init(credentials: .clientSecret(secret: "test")), session: session, sendApplyEvent: true)
+            options: .init(credentials: .clientSecret(secret: "test")), session: session, applyOnResolve: true)
 
         let value = try client.resolve(flag: "flag1", ctx: MutableContext(targetingKey: "user1"))
         XCTAssertEqual(resolvedFlag1.value, value.resolvedValue.value)
@@ -37,7 +37,7 @@ class RemoteKonfidensClientTest: XCTestCase {
         let session = MockedKonfidensClientURLProtocol.mockedSession(flags: flags)
 
         let client = RemoteKonfidensClient(
-            options: .init(credentials: .clientSecret(secret: "test")), session: session, sendApplyEvent: true)
+            options: .init(credentials: .clientSecret(secret: "test")), session: session, applyOnResolve: true)
 
         let result = try client.batchResolve(ctx: MutableContext(targetingKey: "user1"))
         XCTAssertEqual(result.resolvedValues.count, 2)
@@ -54,7 +54,7 @@ class RemoteKonfidensClientTest: XCTestCase {
         let session = MockedKonfidensClientURLProtocol.mockedSession(flags: flags)
 
         let client = RemoteKonfidensClient(
-            options: .init(credentials: .clientSecret(secret: "test")), session: session, sendApplyEvent: true)
+            options: .init(credentials: .clientSecret(secret: "test")), session: session, applyOnResolve: true)
 
         try client.apply(flag: "flag1", resolveToken: "test", appliedTime: Date.backport.now)
     }


### PR DESCRIPTION
Renamed field in proto:
`sendApplyEvent` -> `apply`

Tests for this provider were still green because:
- "Implicit apply" in any Resolve request was defaulted to "false" in the backend; 
- From this CI we don't test that `flag-assigned` is created when resolving a flag with "implicit apply";

Still unclear:
- Explicit calls to the "apply" endpoint are still performed in the IT tests (from the BatchProvider), so some `flag-assigned` data should still be expected for the new flag in https://github.com/spotify/openfeature-swift-provider/pull/6 (something that can be debugged outside of the scope of this PR)