### PR TITLE
Fix missing env var propagation for tests

### DIFF
--- a/Tests/KonfidensProviderTests/KonfidensIntegrationTest.swift
+++ b/Tests/KonfidensProviderTests/KonfidensIntegrationTest.swift
@@ -6,7 +6,14 @@ import XCTest
 
 class Konfidens: XCTestCase {
     let clientToken = ProcessInfo.processInfo.environment["KONFIDENS_CLIENT_TOKEN"]
-    let resolveFlag = ProcessInfo.processInfo.environment["TEST_FLAG_NAME"] ?? "test-flag-1"
+    let resolveFlag = setResolveFlag()
+
+    private static func setResolveFlag() -> String {
+        if let flag = ProcessInfo.processInfo.environment["TEST_FLAG_NAME"], !flag.isEmpty {
+            return flag
+        }
+        return "test-flag-1"
+    }
 
     override func setUp() {
         try? PersistentBatchProviderCache.fromDefaultStorage().clear()

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -6,7 +6,7 @@ script_dir=$(dirname $0)
 root_dir="$script_dir/../"
 
 (cd $root_dir &&
-    TEST_RUNNER_KONFIDENS_CLIENT_TOKEN=$1 xcodebuild \
+    TEST_RUNNER_KONFIDENS_CLIENT_TOKEN=$1 TEST_RUNNER_TEST_FLAG_NAME=$2 xcodebuild \
         -scheme KonfidensProvider \
         -sdk "iphonesimulator" \
         -destination 'platform=iOS Simulator,name=iPhone 14 Pro,OS=16.2' \


### PR DESCRIPTION
This explains the issue of missing "flag-assigned" data mentioned in #7, as the incorrect flag was resolved in the E2E tests