### PR TITLE
Don't throw when apply status is valid

### DIFF
--- a/Sources/KonfidensProvider/Cache/ProviderCache.swift
+++ b/Sources/KonfidensProvider/Cache/ProviderCache.swift
@@ -6,7 +6,7 @@ public protocol ProviderCache {
 
     func clearAndSetValues(values: [ResolvedValue], ctx: EvaluationContext, resolveToken: String) throws
 
-    func updateApplyStatus(flag: String, ctx: EvaluationContext, resolveToken: String, applyStatus: ApplyStatus) throws
+    func updateApplyStatus(flag: String, ctx: EvaluationContext, resolveToken: String, applyStatus: ApplyStatus) throws -> Bool
 }
 
 public struct CacheGetValueResult {

--- a/Sources/KonfidensProvider/KonfidensFeatureProvider.swift
+++ b/Sources/KonfidensProvider/KonfidensFeatureProvider.swift
@@ -175,19 +175,20 @@ public class KonfidensFeatureProvider: FeatureProvider {
 
         let flag = resolverResult.resolvedValue.flag
         do {
-            try cache.updateApplyStatus(
-                flag: flag, ctx: ctx, resolveToken: resolveToken, applyStatus: .applying)
-            executeApply(client: client, flag: flag, resolveToken: resolveToken) { success in
-                do {
-                    if success {
-                        try self.cache.updateApplyStatus(
-                            flag: flag, ctx: ctx, resolveToken: resolveToken, applyStatus: .applied)
-                    } else {
-                        try self.cache.updateApplyStatus(
-                            flag: flag, ctx: ctx, resolveToken: resolveToken, applyStatus: .applyFailed)
+            if (try cache.updateApplyStatus(
+                flag: flag, ctx: ctx, resolveToken: resolveToken, applyStatus: .applying)) {
+                executeApply(client: client, flag: flag, resolveToken: resolveToken) { success in
+                    do {
+                        if success {
+                            let _ = try self.cache.updateApplyStatus(
+                                flag: flag, ctx: ctx, resolveToken: resolveToken, applyStatus: .applied)
+                        } else {
+                            let _ = try self.cache.updateApplyStatus(
+                                flag: flag, ctx: ctx, resolveToken: resolveToken, applyStatus: .applyFailed)
+                        }
+                    } catch let error {
+                        self.logApplyError(error: error)
                     }
-                } catch let error {
-                    self.logApplyError(error: error)
                 }
             }
         } catch let error {

--- a/Tests/KonfidensProviderTests/LocalStorageResolverTest.swift
+++ b/Tests/KonfidensProviderTests/LocalStorageResolverTest.swift
@@ -58,7 +58,7 @@ class TestCache: ProviderCache {
         ctx: OpenFeature.EvaluationContext,
         resolveToken: String,
         applyStatus: KonfidensProvider.ApplyStatus
-    ) throws {}
+    ) throws -> Bool { return true }
 
     func getCurResolveToken() -> String? {
         return nil


### PR DESCRIPTION
This removes the error logs printed when a flag that has been applied once is then read again from the hosting application (which, in turn, doesn't cause another `apply` in the current setup)