### PR TITLE
Local overrides have reason STATIC

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "git@github.com:spotify/openfeature-swift-sdk.git",
         "state": {
           "branch": null,
-          "revision": "239d1017fec404927894c792b6608e4616ed5913",
-          "version": "0.2.2"
+          "revision": "7b4999703f6841346b4d5f127daced7549884d9c",
+          "version": "0.2.3"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
             targets: ["ConfidenceProvider"])
     ],
     dependencies: [
-        .package(url: "git@github.com:spotify/openfeature-swift-sdk.git", from: "0.2.2"),
+        .package(url: "git@github.com:spotify/openfeature-swift-sdk.git", from: "0.2.3"),
     ],
     targets: [
         .target(

--- a/Sources/ConfidenceProvider/ConfidenceFeatureProvider.swift
+++ b/Sources/ConfidenceProvider/ConfidenceFeatureProvider.swift
@@ -148,7 +148,7 @@ public class ConfidenceFeatureProvider: FeatureProvider {
             return ProviderEvaluation(
                 value: overrideValue.value,
                 variant: overrideValue.variant,
-                reason: Reason.defaultReason.rawValue)
+                reason: Reason.staticReason.rawValue)
         }
 
         guard let ctx = ctx else {

--- a/Tests/ConfidenceProviderTests/ConfidenceFeatureProviderTest.swift
+++ b/Tests/ConfidenceProviderTests/ConfidenceFeatureProviderTest.swift
@@ -569,7 +569,7 @@ class ConfidenceFeatureProviderTest: XCTestCase {
             context: MutableContext(targetingKey: "user1"))
 
         XCTAssertEqual(evaluation.variant, "control")
-        XCTAssertEqual(evaluation.reason, Reason.defaultReason.rawValue)
+        XCTAssertEqual(evaluation.reason, Reason.staticReason.rawValue)
         XCTAssertEqual(evaluation.value, 4)
         XCTAssertEqual(MockedConfidenceClientURLProtocol.resolveStats, 1)
         XCTAssertEqual(MockedConfidenceClientURLProtocol.applyStats, 0)
@@ -596,7 +596,7 @@ class ConfidenceFeatureProviderTest: XCTestCase {
             context: MutableContext(targetingKey: "user1"))
 
         XCTAssertEqual(sizeEvaluation.variant, "treatment")
-        XCTAssertEqual(sizeEvaluation.reason, Reason.defaultReason.rawValue)
+        XCTAssertEqual(sizeEvaluation.reason, Reason.staticReason.rawValue)
         XCTAssertEqual(sizeEvaluation.value, 4)
 
         let colorEvaluation = try provider.getStringEvaluation(
@@ -631,7 +631,7 @@ class ConfidenceFeatureProviderTest: XCTestCase {
             context: nil)
 
         XCTAssertEqual(sizeEvaluation1.variant, "treatment")
-        XCTAssertEqual(sizeEvaluation1.reason, Reason.defaultReason.rawValue)
+        XCTAssertEqual(sizeEvaluation1.reason, Reason.staticReason.rawValue)
         XCTAssertEqual(sizeEvaluation1.value, 4)
 
         provider.initialize(initialContext: MutableContext(targetingKey: "user1"))
@@ -642,7 +642,7 @@ class ConfidenceFeatureProviderTest: XCTestCase {
             context: MutableContext(targetingKey: "user1"))
 
         XCTAssertEqual(sizeEvaluation2.variant, "treatment")
-        XCTAssertEqual(sizeEvaluation2.reason, Reason.defaultReason.rawValue)
+        XCTAssertEqual(sizeEvaluation2.reason, Reason.staticReason.rawValue)
         XCTAssertEqual(sizeEvaluation2.value, 4)
         XCTAssertEqual(MockedConfidenceClientURLProtocol.resolveStats, 1)
         XCTAssertEqual(MockedConfidenceClientURLProtocol.applyStats, 0)
@@ -670,7 +670,7 @@ class ConfidenceFeatureProviderTest: XCTestCase {
             context: MutableContext(targetingKey: "user1"))
 
         XCTAssertEqual(evaluation.variant, "treatment")
-        XCTAssertEqual(evaluation.reason, Reason.defaultReason.rawValue)
+        XCTAssertEqual(evaluation.reason, Reason.staticReason.rawValue)
         XCTAssertEqual(evaluation.value, 5)
         XCTAssertEqual(MockedConfidenceClientURLProtocol.resolveStats, 1)
         XCTAssertEqual(MockedConfidenceClientURLProtocol.applyStats, 0)
@@ -699,7 +699,7 @@ class ConfidenceFeatureProviderTest: XCTestCase {
             context: MutableContext(targetingKey: "user1"))
 
         XCTAssertEqual(evaluation.variant, "treatment")
-        XCTAssertEqual(evaluation.reason, Reason.defaultReason.rawValue)
+        XCTAssertEqual(evaluation.reason, Reason.staticReason.rawValue)
         XCTAssertEqual(evaluation.value, 5)
         XCTAssertEqual(MockedConfidenceClientURLProtocol.applyStats, 0)
     }


### PR DESCRIPTION
Waits on: https://github.com/spotify/openfeature-swift-sdk/pull/11

Description of STATIC: https://openfeature.dev/specification/types/#resolution-details
Looks like the better fit for our local override use-case