### PR TITLE
Change to OpenFeature flag not found error

### DIFF
--- a/Sources/ConfidenceProvider/ConfidenceClient/LocalStorageResolver.swift
+++ b/Sources/ConfidenceProvider/ConfidenceClient/LocalStorageResolver.swift
@@ -11,7 +11,7 @@ public class LocalStorageResolver: Resolver {
     public func resolve(flag: String, ctx: EvaluationContext) throws -> ResolveResult {
         let getResult = try self.cache.getValue(flag: flag, ctx: ctx)
         guard let getResult = getResult else {
-            throw ConfidenceError.flagNotFoundInCache
+            throw OpenFeatureError.flagNotFoundError(key: flag)
         }
         guard !getResult.needsUpdate else {
             throw ConfidenceError.cachedValueExpired

--- a/Tests/ConfidenceProviderTests/ConfidenceFeatureProviderTest.swift
+++ b/Tests/ConfidenceProviderTests/ConfidenceFeatureProviderTest.swift
@@ -35,8 +35,7 @@ class ConfidenceFeatureProviderTest: XCTestCase {
         ) { error in
             XCTAssertEqual(
                 error as? OpenFeatureError,
-                OpenFeatureError.generalError(
-                    message: "Error during string evaluation for key flag.size: Flag not found in the cache"))
+                OpenFeatureError.flagNotFoundError(key: "flag"))
         }
 
         let resolve: [String: MockedConfidenceClientURLProtocol.ResolvedTestFlag] = [
@@ -480,8 +479,7 @@ class ConfidenceFeatureProviderTest: XCTestCase {
         ) { error in
             XCTAssertEqual(
                 error as? OpenFeatureError,
-                OpenFeatureError.generalError(
-                    message: "Error during object evaluation for key flag: Flag not found in the cache"))
+                OpenFeatureError.flagNotFoundError(key: "flag"))
         }
         XCTAssertEqual(MockedConfidenceClientURLProtocol.resolveStats, 1)
         XCTAssertEqual(MockedConfidenceClientURLProtocol.applyStats, 0)

--- a/Tests/ConfidenceProviderTests/LocalStorageResolverTest.swift
+++ b/Tests/ConfidenceProviderTests/LocalStorageResolverTest.swift
@@ -27,7 +27,7 @@ class LocalStorageResolverTest: XCTestCase {
             try resolver.resolve(flag: "test", ctx: ctx)
         ) { error in
             XCTAssertEqual(
-                error as? ConfidenceError, ConfidenceError.flagNotFoundInCache)
+                error as? OpenFeatureError, OpenFeatureError.flagNotFoundError(key: "test"))
         }
     }
 }


### PR DESCRIPTION
Use the OpenFeatureError for flag not found, this stops loss of context if a flag isn't found.