### PR TITLE
Breaking retain cycle in Persistent Provider Cache

### DIFF
--- a/Sources/ConfidenceProvider/Cache/PersistentProviderCache.swift
+++ b/Sources/ConfidenceProvider/Cache/PersistentProviderCache.swift
@@ -23,7 +23,8 @@ public class PersistentProviderCache: ProviderCache {
 
         persistPublisher
             .throttle(for: 30.0, scheduler: persistQueue, latest: true)
-            .sink { _ in
+            .sink { [weak self] _ in
+                guard let self else { return }
                 do {
                     try self.persist()
                 } catch {


### PR DESCRIPTION
`self` had been referenced strongly in the sink closure, resulting in a retain cycle.