### PR TITLE
feat: add functionality to manual flush events

### DIFF
--- a/ConfidenceDemoApp/ConfidenceDemoApp/ContentView.swift
+++ b/ConfidenceDemoApp/ConfidenceDemoApp/ContentView.swift
@@ -32,6 +32,9 @@ struct ContentView: View {
                         color.color = .red
                     }
                 }
+                Button("Flush 🚽") {
+                    confidence.flush()
+                }
             }
             .padding()
         } else if case .error(let error) = status.state {

--- a/Sources/Confidence/Confidence.swift
+++ b/Sources/Confidence/Confidence.swift
@@ -308,7 +308,7 @@ extension Confidence {
                 clientSecret: clientSecret,
                 uploader: uploader,
                 storage: eventStorage,
-                flushPolicies: [SizeFlushPolicy(batchSize: 1)])
+                flushPolicies: [SizeFlushPolicy(batchSize: 10)])
             return Confidence(
                 clientSecret: clientSecret,
                 region: region,

--- a/Sources/Confidence/Confidence.swift
+++ b/Sources/Confidence/Confidence.swift
@@ -145,6 +145,10 @@ public class Confidence: ConfidenceEventSender {
         }
     }
 
+    public func flush() {
+        eventSenderEngine.flush()
+    }
+
     private func withLock(callback: @escaping (Confidence) -> Void) {
         confidenceQueue.sync {  [weak self] in
             guard let self = self else {

--- a/Sources/Confidence/ConfidenceEventSender.swift
+++ b/Sources/Confidence/ConfidenceEventSender.swift
@@ -13,4 +13,9 @@ public protocol ConfidenceEventSender: Contextual {
     The ConfidenceProducer can be used to push context changes or event tracking
     */
     func track(producer: ConfidenceProducer)
+
+    /**
+    Schedule a manual flush of the event data currently stored on disk
+    */
+    func flush()
 }

--- a/Sources/Confidence/ManualFlushPolicy.swift
+++ b/Sources/Confidence/ManualFlushPolicy.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+let manualFlushEvent = ConfidenceEvent(name: "manual_flush", payload: [:], eventTime: Date.backport.now)
+
+class ManualFlushPolicy: FlushPolicy {
+    private var flushRequested = false
+
+    func reset() {
+        flushRequested = false
+    }
+
+    func hit(event: ConfidenceEvent) {
+        flushRequested = event.name == manualFlushEvent.name
+    }
+
+    func shouldFlush() -> Bool {
+        return flushRequested
+    }
+}

--- a/Tests/ConfidenceTests/EventUploaderMock.swift
+++ b/Tests/ConfidenceTests/EventUploaderMock.swift
@@ -18,8 +18,8 @@ final class EventUploaderMock: ConfidenceClient {
 }
 
 final class EventStorageMock: EventStorage {
-    private var events: [ConfidenceEvent] = []
-    private var batches: [String: [ConfidenceEvent]] = [:]
+    var events: [ConfidenceEvent] = []
+    var batches: [String: [ConfidenceEvent]] = [:]
     var removeCallback: () -> Void = {}
 
     func startNewBatch() throws {

--- a/Tests/ConfidenceTests/Helpers/EventSenderEngineMock.swift
+++ b/Tests/ConfidenceTests/Helpers/EventSenderEngineMock.swift
@@ -9,4 +9,8 @@ class EventSenderEngineMock: EventSenderEngine {
     func shutdown() {
         // NO-OP
     }
+
+    func flush() {
+        // NO-OP
+    }
 }


### PR DESCRIPTION
We want to allow for the user to manually trigger an upload to the backend services for all events emitted up to that point. 

The approach used in this PR is to treat a call to the `flush()` method as a special event emitted, which will mean that the events in the "write channel" will be guaranteed to have been written to disk (and thus applicable to be part of the "batch" to upload) before the actual flush happens.  