### PR TITLE
feat: introduce a writeQueue for event tracking

### DIFF
--- a/Sources/Confidence/Confidence.swift
+++ b/Sources/Confidence/Confidence.swift
@@ -311,8 +311,7 @@ extension Confidence {
             let eventSenderEngine = EventSenderEngineImpl(
                 clientSecret: clientSecret,
                 uploader: uploader,
-                storage: eventStorage,
-                flushPolicies: [SizeFlushPolicy(batchSize: 10)])
+                storage: eventStorage)
             return Confidence(
                 clientSecret: clientSecret,
                 region: region,

--- a/Tests/ConfidenceTests/EventSenderEngineTest.swift
+++ b/Tests/ConfidenceTests/EventSenderEngineTest.swift
@@ -125,7 +125,6 @@ final class EventSenderEngineTest: XCTestCase {
     }
 
     func testKeepEventsInStorageForRetry() throws {
-        let expectation = self.expectation(description: "Writes handled")
         MockedClientURLProtocol.mockedOperation = .needRetryLater
         let retryLaterUploader = RemoteConfidenceClient(
             options: ConfidenceClientOptions(credentials: ConfidenceClientCredentials.clientSecret(secret: "")),
@@ -142,16 +141,9 @@ final class EventSenderEngineTest: XCTestCase {
 
         eventSenderEngine.emit(eventName: "testEvent", message: ConfidenceStruct(), context: ConfidenceStruct())
 
-        writeQueue.async {
-            // Give some time for the events to be processed
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                expectation.fulfill()
-            }
+        writeQueue.sync {
+            XCTAssertEqual(storageMock.isEmpty(), false)
         }
-
-        waitForExpectations(timeout: 1.0, handler: nil)
-
-        XCTAssertEqual(storageMock.isEmpty(), false)
     }
 
     func testManualFlushWorks() throws {

--- a/Tests/ConfidenceTests/EventSenderEngineTest.swift
+++ b/Tests/ConfidenceTests/EventSenderEngineTest.swift
@@ -147,7 +147,6 @@ final class EventSenderEngineTest: XCTestCase {
     }
 
     func testManualFlushWorks() throws {
-        let writeExpectation = self.expectation(description: "Writes handled")
         let eventSenderEngine = EventSenderEngineImpl(
             clientSecret: "CLIENT_SECRET",
             uploader: uploaderMock,
@@ -163,17 +162,10 @@ final class EventSenderEngineTest: XCTestCase {
         eventSenderEngine.emit(eventName: "Hello", message: [:], context: [:])
 
 
-        writeQueue.async {
-            // Give some time for the events to be processed
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                writeExpectation.fulfill()
-            }
+        writeQueue.sync {
+            XCTAssertEqual(storageMock.events.count, 4)
+            XCTAssertNil(uploaderMock.calledRequest)
         }
-
-        waitForExpectations(timeout: 1.0, handler: nil)
-
-        XCTAssertEqual(storageMock.events.count, 4)
-        XCTAssertNil(uploaderMock.calledRequest)
 
         eventSenderEngine.flush()
 


### PR DESCRIPTION
the write queue will consume one tracked event after the other and write them to disk and run the flush policies