### PR TITLE
refactor: remove is_foreground from event producer

### DIFF
--- a/Sources/Confidence/ConfidenceAppLifecycleProducer.swift
+++ b/Sources/Confidence/ConfidenceAppLifecycleProducer.swift
@@ -87,16 +87,6 @@ public class ConfidenceAppLifecycleProducer: ConfidenceEventProducer, Confidence
         UserDefaults.standard.setValue(currentBuild, forKey: Self.userDefaultBuildNameKey)
     }
 
-    private func updateContext() {
-        withLock { [weak self] in
-            guard let self = self else {
-                return
-            }
-            let context = self.currentProducedContext.value
-            self.currentProducedContext.send(context)
-        }
-    }
-
     private func withLock(callback: @escaping () -> Void) {
         queue.sync {
             callback()

--- a/Sources/Confidence/ConfidenceAppLifecycleProducer.swift
+++ b/Sources/Confidence/ConfidenceAppLifecycleProducer.swift
@@ -19,7 +19,6 @@ public class ConfidenceAppLifecycleProducer: ConfidenceEventProducer, Confidence
     // Context Keys
     private static var versionNameContextKey = "app_version"
     private static var buildNumberContextKey = "app_build"
-    private static var isForegroundContextKey = "is_foreground"
     // Event Names
     private static let appLaunchedEventName = "app-launched"
     private static let appInstalledEventName = "app-installed"
@@ -88,13 +87,12 @@ public class ConfidenceAppLifecycleProducer: ConfidenceEventProducer, Confidence
         UserDefaults.standard.setValue(currentBuild, forKey: Self.userDefaultBuildNameKey)
     }
 
-    private func updateContext(isForeground: Bool) {
+    private func updateContext() {
         withLock { [weak self] in
             guard let self = self else {
                 return
             }
-            var context = self.currentProducedContext.value
-            context.updateValue(.init(boolean: isForeground), forKey: Self.isForegroundContextKey)
+            let context = self.currentProducedContext.value
             self.currentProducedContext.send(context)
         }
     }
@@ -107,10 +105,6 @@ public class ConfidenceAppLifecycleProducer: ConfidenceEventProducer, Confidence
 
     @objc func notificationResponse(notification: NSNotification) {
         switch notification.name {
-        case UIApplication.didEnterBackgroundNotification:
-            updateContext(isForeground: false)
-        case UIApplication.willEnterForegroundNotification:
-            updateContext(isForeground: true)
         case UIApplication.didBecomeActiveNotification:
             track(eventName: Self.appLaunchedEventName, shouldFlush: true)
         default:

--- a/Sources/Confidence/ConfidenceScreenTracker.swift
+++ b/Sources/Confidence/ConfidenceScreenTracker.swift
@@ -78,10 +78,8 @@ extension UIViewController {
                 let encoder = JSONEncoder()
                 do {
                     let data = try encoder.encode(trackableWithMessage.trackMessage())
-                    let messageString = String(data: data, encoding: .utf8)
-                    if let json = messageString {
-                        message.updateValue(json, forKey: ConfidenceScreenTracker.messageKey)
-                    }
+                    let messageString = String(decoding: data, as: UTF8.self)
+                    message.updateValue(messageString, forKey: ConfidenceScreenTracker.messageKey)
                 } catch {
                 }
             }

--- a/Sources/Confidence/EventStorage.swift
+++ b/Sources/Confidence/EventStorage.swift
@@ -50,10 +50,7 @@ internal class EventStorageImpl: EventStorage {
             }
             let encoder = JSONEncoder()
             let serialied = try encoder.encode(event)
-            let delimiter = "\n".data(using: .utf8)
-            guard let delimiter else {
-                return
-            }
+            let delimiter = Data("\n".utf8)
             currentFileHandle.seekToEndOfFile()
             try currentFileHandle.write(contentsOf: delimiter)
             try currentFileHandle.write(contentsOf: serialied)
@@ -78,8 +75,8 @@ internal class EventStorageImpl: EventStorage {
             let decoder = JSONDecoder()
             let fileUrl = folderURL.appendingPathComponent(id)
             let data = try Data(contentsOf: fileUrl)
-            let dataString = String(data: data, encoding: .utf8)
-            return try dataString?.components(separatedBy: "\n")
+            let dataString = String(decoding: data, as: UTF8.self)
+            return try dataString.components(separatedBy: "\n")
                 .filter { events in
                     !events.isEmpty
                 }
@@ -88,7 +85,7 @@ internal class EventStorageImpl: EventStorage {
                         return nil
                     }
                     return try decoder.decode(ConfidenceEvent.self, from: stringData)
-                } ?? []
+                }
         }
     }
 

--- a/Sources/Confidence/Http/NetworkClient.swift
+++ b/Sources/Confidence/Http/NetworkClient.swift
@@ -131,10 +131,10 @@ extension NetworkClient {
                 do {
                     response.decodedError = try decoder.decode(HttpError.self, from: responseData)
                 } catch {
-                    let message = String(data: responseData, encoding: String.Encoding.utf8)
+                    let message = String(decoding: responseData, as: UTF8.self)
                     response.decodedError = HttpError(
                         code: httpURLResponse.statusCode,
-                        message: message ?? "unknown",
+                        message: message,
                         details: []
                     )
                 }

--- a/Tests/ConfidenceTests/ConfidenceValueTests.swift
+++ b/Tests/ConfidenceTests/ConfidenceValueTests.swift
@@ -124,7 +124,8 @@ final class ConfidenceConfidenceValueTests: XCTestCase {
         ]))
         let encoder = JSONEncoder()
         encoder.outputFormatting = .sortedKeys
-        let resultString = try XCTUnwrap(String(data: try encoder.encode(value), encoding: .utf8))
+        let data = try encoder.encode(value)
+        let resultString = try XCTUnwrap(String(decoding: data, as: UTF8.self))
         let resultData = try XCTUnwrap(resultString.data(using: .utf8))
         let decodedValue = try JSONDecoder().decode(ConfidenceValue.self, from: resultData)
 

--- a/Tests/ConfidenceTests/Helpers/StorageMock.swift
+++ b/Tests/ConfidenceTests/Helpers/StorageMock.swift
@@ -17,7 +17,7 @@ class StorageMock: Storage {
     func save(data: Encodable) throws {
         try storageQueue.sync {
             let dataB = try JSONEncoder().encode(data)
-            self.data = String(data: dataB, encoding: .utf8) ?? ""
+            self.data = String(decoding: dataB, as: UTF8.self)
 
             saveExpectation?.fulfill()
         }


### PR DESCRIPTION
This PR removed is_foreground from AppLifecycleEventProducer.