### PR TITLE
fix: targeting_key conversion

### DIFF
--- a/ConfidenceDemoApp/ConfidenceDemoApp/ConfidenceDemoApp.swift
+++ b/ConfidenceDemoApp/ConfidenceDemoApp/ConfidenceDemoApp.swift
@@ -44,7 +44,7 @@ struct ConfidenceDemoApp: App {
 extension ConfidenceDemoApp {
     func setup(confidence: Confidence) async throws {
         try await confidence.fetchAndActivate()
-        confidence.track(
+        try confidence.track(
             eventName: "all-types",
             data: [
                 "my_string": ConfidenceValue(string: "hello_from_world"),

--- a/Sources/ConfidenceProvider/ConfidenceTypeMapper.swift
+++ b/Sources/ConfidenceProvider/ConfidenceTypeMapper.swift
@@ -8,9 +8,15 @@ public enum ConfidenceTypeMapper {
     }
 
     static func from(ctx: EvaluationContext?) -> ConfidenceStruct {
-        var ctxMap = ctx?.asMap() ?? [:]
-        ctxMap["targeting_key"] = .string(ctx?.getTargetingKey() ?? "")
-        return ctxMap.compactMapValues(convertValue)
+        guard let openFeatureContext = ctx else {
+            return [:]
+        }
+        var ofCtxMap = openFeatureContext.asMap()
+        // Precendence given to the `attributes` rather then the bespoke `targeting_key`
+        if !openFeatureContext.getTargetingKey().isEmpty && !ofCtxMap.keys.contains("targeting_key") {
+            ofCtxMap["targeting_key"] = .string(openFeatureContext.getTargetingKey())
+        }
+        return ofCtxMap.compactMapValues(convertValue)
     }
 
     // swiftlint:disable:next cyclomatic_complexity

--- a/Tests/ConfidenceProviderTests/ConfidenceTypeMapperTest.swift
+++ b/Tests/ConfidenceProviderTests/ConfidenceTypeMapperTest.swift
@@ -18,6 +18,50 @@ class ValueConverterTest: XCTestCase {
         XCTAssertEqual(confidenceStruct, expected)
     }
 
+    func testContextConversionTargetingKey() throws {
+        let openFeatureCtx = MutableContext(
+            targetingKey: "",
+            structure: MutableStructure(attributes: (["targeting_key": .string("userid")])))
+        let confidenceStruct = ConfidenceTypeMapper.from(ctx: openFeatureCtx)
+        let expected = [
+            "targeting_key": ConfidenceValue(string: "userid")
+        ]
+        XCTAssertEqual(confidenceStruct, expected)
+    }
+
+    func testContextConversionTargetingKeyPrecendence() throws {
+        let openFeatureCtx = MutableContext(
+            targetingKey: "userid-1",
+            structure: MutableStructure(attributes: (["targeting_key": .string("userid-2")])))
+        let confidenceStruct = ConfidenceTypeMapper.from(ctx: openFeatureCtx)
+        let expected = [
+            "targeting_key": ConfidenceValue(string: "userid-2")
+        ]
+        XCTAssertEqual(confidenceStruct, expected)
+    }
+
+    func testContextConversionTargetingKeyPrecendence3() throws {
+        let openFeatureCtx = MutableContext(
+            targetingKey: "userid-1",
+            structure: MutableStructure(attributes: (["targeting_key": .string("")])))
+        let confidenceStruct = ConfidenceTypeMapper.from(ctx: openFeatureCtx)
+        let expected = [
+            "targeting_key": ConfidenceValue(string: "")
+        ]
+        XCTAssertEqual(confidenceStruct, expected)
+    }
+
+    func testContextConversionTargetingKeyPrecendence2() throws {
+        let openFeatureCtx = MutableContext(
+            targetingKey: "userid-1",
+            structure: MutableStructure(attributes: ([:])))
+        let confidenceStruct = ConfidenceTypeMapper.from(ctx: openFeatureCtx)
+        let expected = [
+            "targeting_key": ConfidenceValue(string: "userid-1")
+        ]
+        XCTAssertEqual(confidenceStruct, expected)
+    }
+
     func testContextConversionWithLists() throws {
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"


### PR DESCRIPTION
"targeting_key" was not propagated correctly in this example (i.e. `targeting_key` was set to an empty string):
```
        let initCtx = MutableContext(attributes: ["targeting_key": .string("user1")])
        await OpenFeatureAPI.shared.setProviderAndWait(
            provider: ConfidenceFeatureProvider(
                confidence: confidence,
                initializationStrategy: InitializationStrategy.fetchAndActivate),
            initialContext: initCtx)
```