### PR TITLE
fix: Issues with context/secret trigger error

### DIFF
--- a/Sources/Confidence/Confidence.swift
+++ b/Sources/Confidence/Confidence.swift
@@ -53,7 +53,7 @@ public class Confidence: ConfidenceEventSender {
                     try await self.fetchAndActivate()
                     self.contextReconciliatedChanges.send(context.hash())
                 } catch {
-                    // Log errors for debugging
+                    // TODO: Log errors for debugging
                 }
             }
         }
@@ -75,7 +75,7 @@ public class Confidence: ConfidenceEventSender {
         do {
             try await internalFetch()
         } catch {
-            // Log errors for debugging
+            // TODO: Log errors for debugging
         }
         try activate()
     }

--- a/Sources/Confidence/Confidence.swift
+++ b/Sources/Confidence/Confidence.swift
@@ -53,6 +53,7 @@ public class Confidence: ConfidenceEventSender {
                     try await self.fetchAndActivate()
                     self.contextReconciliatedChanges.send(context.hash())
                 } catch {
+                    // Log errors for debugging
                 }
             }
         }
@@ -64,8 +65,18 @@ public class Confidence: ConfidenceEventSender {
         self.cache = savedFlags
     }
 
+    /**
+    Fetches latest flag evaluations and store them on disk. Regardless of the fetch outcome (success or failure), this
+    function activates the cache after the fetch.
+    Activating the cache means that the flag data on disk is loaded into memory, so consumers can access flag values.
+    Fetching is best-effort, so no error is propagated. Errors can still be thrown if something goes wrong access data on disk.
+    */
     public func fetchAndActivate() async throws {
-        try await internalFetch()
+        do {
+            try await internalFetch()
+        } catch {
+            // Log errors for debugging
+        }
         try activate()
     }
 

--- a/Sources/Confidence/Confidence.swift
+++ b/Sources/Confidence/Confidence.swift
@@ -59,7 +59,10 @@ public class Confidence: ConfidenceEventSender {
         }
         .store(in: &cancellables)
     }
-
+    /**
+    Activating the cache means that the flag data on disk is loaded into memory, so consumers can access flag values.
+    Errors can be thrown if something goes wrong access data on disk.
+    */
     public func activate() throws {
         let savedFlags = try storage.load(defaultValue: FlagResolution.EMPTY)
         self.cache = savedFlags
@@ -91,9 +94,17 @@ public class Confidence: ConfidenceEventSender {
         try storage.save(data: resolution)
     }
 
+    /**
+    Fetches latest flag evaluations and store them on disk. Note that "activate" must be called for this data to be
+    made available in the app session.
+    */
     public func asyncFetch() {
         Task {
-            try await internalFetch()
+            do {
+                try await internalFetch()
+            } catch {
+                // TODO: Log errors for debugging
+            }
         }
     }
 

--- a/Sources/ConfidenceProvider/ConfidenceFeatureProvider.swift
+++ b/Sources/ConfidenceProvider/ConfidenceFeatureProvider.swift
@@ -39,12 +39,7 @@ public class ConfidenceFeatureProvider: FeatureProvider {
     }
 
     public func initialize(initialContext: OpenFeature.EvaluationContext?) {
-        guard let initialContext = initialContext else {
-            eventHandler.send(.error)
-            return
-        }
-
-        self.updateConfidenceContext(context: initialContext)
+        self.updateConfidenceContext(context: initialContext ?? MutableContext(attributes: [:]))
         if self.initializationStrategy == .activateAndFetchAsync {
             eventHandler.send(.ready)
         }

--- a/Sources/ConfidenceProvider/ConfidenceFeatureProvider.swift
+++ b/Sources/ConfidenceProvider/ConfidenceFeatureProvider.swift
@@ -56,8 +56,12 @@ public class ConfidenceFeatureProvider: FeatureProvider {
                 confidence.asyncFetch()
             } else {
                 Task {
-                    try await confidence.fetchAndActivate()
-                    eventHandler.send(.ready)
+                    do {
+                        try await confidence.fetchAndActivate()
+                        eventHandler.send(.ready)
+                    } catch {
+                        eventHandler.send(.error)
+                    }
                 }
             }
         } catch {

--- a/Sources/ConfidenceProvider/ConfidenceFeatureProvider.swift
+++ b/Sources/ConfidenceProvider/ConfidenceFeatureProvider.swift
@@ -40,6 +40,7 @@ public class ConfidenceFeatureProvider: FeatureProvider {
 
     public func initialize(initialContext: OpenFeature.EvaluationContext?) {
         guard let initialContext = initialContext else {
+            eventHandler.send(.error)
             return
         }
 

--- a/Tests/ConfidenceProviderTests/ConfidenceProviderTest.swift
+++ b/Tests/ConfidenceProviderTests/ConfidenceProviderTest.swift
@@ -6,7 +6,6 @@ import XCTest
 
 @testable import Confidence
 
-@available(macOS 13.0, iOS 16.0, *)
 class ConfidenceTest: XCTestCase {
     private var readyExpectation = XCTestExpectation(description: "Ready")
     private var errorExpectation = XCTestExpectation(description: "Error")

--- a/Tests/ConfidenceProviderTests/ConfidenceProviderTest.swift
+++ b/Tests/ConfidenceProviderTests/ConfidenceProviderTest.swift
@@ -6,7 +6,7 @@ import XCTest
 
 @testable import Confidence
 
-class ConfidenceTest: XCTestCase {
+class ConfidenceProviderTest: XCTestCase {
     private var readyExpectation = XCTestExpectation(description: "Ready")
     private var errorExpectation = XCTestExpectation(description: "Error")
 

--- a/Tests/ConfidenceProviderTests/ConfidenceProviderTest.swift
+++ b/Tests/ConfidenceProviderTests/ConfidenceProviderTest.swift
@@ -1,0 +1,79 @@
+import Foundation
+import ConfidenceProvider
+import Combine
+import OpenFeature
+import XCTest
+
+@testable import Confidence
+
+@available(macOS 13.0, iOS 16.0, *)
+class ConfidenceTest: XCTestCase {
+    private var readyExpectation = XCTestExpectation(description: "Ready")
+    private var errorExpectation = XCTestExpectation(description: "Error")
+
+    func testErrorFetchOnInit() async throws {
+        class FakeClient: ConfidenceResolveClient {
+            func resolve(ctx: ConfidenceStruct) async throws -> ResolvesResult {
+                throw ConfidenceError.internalError(message: "test")
+            }
+        }
+
+        let client = FakeClient()
+        let confidence = Confidence.Builder(clientSecret: "test")
+            .withContext(initialContext: ["targeting_key": .init(string: "user1")])
+            .withFlagResolverClient(flagResolver: client)
+            .build()
+
+        let provider = ConfidenceFeatureProvider(confidence: confidence, initializationStrategy: .activateAndFetchAsync)
+        OpenFeatureAPI.shared.setProvider(provider: provider)
+
+        let cancellable = OpenFeatureAPI.shared.observe().sink { event in
+            if event == .ready {
+                self.readyExpectation.fulfill()
+            } else {
+                print(event)
+            }
+        }
+        await fulfillment(of: [readyExpectation], timeout: 5.0)
+        cancellable.cancel()
+    }
+
+    func testErrorStorageOnInit() async throws {
+        class FakeStorage: Storage {
+            func save(data: Encodable) throws {
+                // no-op
+            }
+            
+            func load<T>(defaultValue: T) throws -> T where T : Decodable {
+                throw ConfidenceError.internalError(message: "test")
+            }
+            
+            func clear() throws {
+                // no-op
+            }
+            
+            func isEmpty() -> Bool {
+                return false
+            }
+            
+        }
+
+        let confidence = Confidence.Builder(clientSecret: "test")
+            .withContext(initialContext: ["targeting_key": .init(string: "user1")])
+            .withStorage(storage: FakeStorage())
+            .build()
+
+        let provider = ConfidenceFeatureProvider(confidence: confidence, initializationStrategy: .activateAndFetchAsync)
+        OpenFeatureAPI.shared.setProvider(provider: provider)
+
+        let cancellable = OpenFeatureAPI.shared.observe().sink { event in
+            if event == .error {
+                self.errorExpectation.fulfill()
+            } else {
+                print(event)
+            }
+        }
+        await fulfillment(of: [errorExpectation], timeout: 5.0)
+        cancellable.cancel()
+    }
+}

--- a/Tests/ConfidenceProviderTests/ConfidenceProviderTest.swift
+++ b/Tests/ConfidenceProviderTests/ConfidenceProviderTest.swift
@@ -42,19 +42,18 @@ class ConfidenceProviderTest: XCTestCase {
             func save(data: Encodable) throws {
                 // no-op
             }
-            
-            func load<T>(defaultValue: T) throws -> T where T : Decodable {
+
+            func load<T>(defaultValue: T) throws -> T where T: Decodable {
                 throw ConfidenceError.internalError(message: "test")
             }
-            
+
             func clear() throws {
                 // no-op
             }
-            
+
             func isEmpty() -> Bool {
                 return false
             }
-            
         }
 
         let confidence = Confidence.Builder(clientSecret: "test")

--- a/Tests/ConfidenceTests/ConfidenceContextTests.swift
+++ b/Tests/ConfidenceTests/ConfidenceContextTests.swift
@@ -2,7 +2,7 @@ import XCTest
 @testable import Confidence
 
 // swiftlint:disable type_body_length
-final class ConfidenceTests: XCTestCase {
+final class ConfidenceContextTests: XCTestCase {
     func testWithContext() {
         let client = RemoteConfidenceResolveClient(
             options: ConfidenceClientOptions(

--- a/Tests/ConfidenceTests/ConfidenceTest.swift
+++ b/Tests/ConfidenceTests/ConfidenceTest.swift
@@ -7,7 +7,7 @@ import XCTest
 @testable import Confidence
 
 @available(macOS 13.0, iOS 16.0, *)
-class ConfidenceFeatureProviderTest: XCTestCase {
+class ConfidenceTest: XCTestCase {
     private var flagApplier = FlagApplierMock()
     private let storage = StorageMock()
     private var readyExpectation = XCTestExpectation(description: "Ready")


### PR DESCRIPTION
This allows the application to continue on `setProviderAndWait`, instead of waiting indefinitely for a `ready` or `error` local-event that will never be triggered.