### PR TITLE
feat: Differentiate OF non-OF in metadata

### DIFF
--- a/Sources/Confidence/ConfidenceClient.swift
+++ b/Sources/Confidence/ConfidenceClient.swift
@@ -7,7 +7,7 @@ protocol ConfidenceClient {
 
 protocol ConfidenceResolveClient {
     // Async
-    func resolve(ctx: ConfidenceStruct) async throws -> ResolvesResult
+    func resolve(ctx: ConfidenceStruct, isProvider: Bool) async throws -> ResolvesResult
 }
 
 struct ResolvedValue: Codable, Equatable {

--- a/Sources/Confidence/FlagEvaluation.swift
+++ b/Sources/Confidence/FlagEvaluation.swift
@@ -25,7 +25,8 @@ extension FlagResolution {
         flagName: String,
         defaultValue: T,
         context: ConfidenceStruct,
-        flagApplier: FlagApplier? = nil
+        flagApplier: FlagApplier? = nil,
+        isProvider: Bool
     ) throws -> Evaluation<T> {
         let parsedKey = try FlagPath.getPath(for: flagName)
         if self == FlagResolution.EMPTY {

--- a/Sources/Confidence/RemoteResolveConfidenceClient.swift
+++ b/Sources/Confidence/RemoteResolveConfidenceClient.swift
@@ -24,13 +24,13 @@ public class RemoteConfidenceResolveClient: ConfidenceResolveClient {
 
     // MARK: Resolver
 
-    public func resolve(flags: [String], ctx: ConfidenceStruct) async throws -> ResolvesResult {
+    public func resolve(flags: [String], ctx: ConfidenceStruct, isProvider: Bool) async throws -> ResolvesResult {
         let request = ResolveFlagsRequest(
             flags: flags.map { "flags/\($0)" },
             evaluationContext: TypeMapper.convert(structure: ctx),
             clientSecret: options.credentials.getSecret(),
             apply: applyOnResolve,
-            sdk: Sdk(id: metadata.name, version: metadata.version)
+            sdk: Sdk(id: isProvider ? "SDK_ID_SWIFT_PROVIDER" : metadata.name, version: metadata.version)
         )
 
         do {
@@ -54,8 +54,8 @@ public class RemoteConfidenceResolveClient: ConfidenceResolveClient {
         }
     }
 
-    public func resolve(ctx: ConfidenceStruct) async throws -> ResolvesResult {
-        return try await resolve(flags: [], ctx: ctx)
+    public func resolve(ctx: ConfidenceStruct, isProvider: Bool) async throws -> ResolvesResult {
+        return try await resolve(flags: [], ctx: ctx, isProvider: isProvider)
     }
 
     // MARK: Private

--- a/Sources/ConfidenceProvider/ConfidenceFeatureProvider.swift
+++ b/Sources/ConfidenceProvider/ConfidenceFeatureProvider.swift
@@ -52,10 +52,10 @@ public class ConfidenceFeatureProvider: FeatureProvider {
             if initializationStrategy == .activateAndFetchAsync {
                 try confidence.activate()
                 eventHandler.send(.ready)
-                confidence.asyncFetch()
+                confidence.asyncFetch(isProvider: true)
             } else {
                 Task {
-                    try await confidence.fetchAndActivate()
+                    try await confidence.fetchAndActivate(isProvider: true)
                     eventHandler.send(.ready)
                 }
             }
@@ -85,37 +85,40 @@ public class ConfidenceFeatureProvider: FeatureProvider {
     }
 
     private func updateConfidenceContext(context: EvaluationContext, removedKeys: [String] = []) {
-        confidence.putContext(context: ConfidenceTypeMapper.from(ctx: context), removeKeys: removedKeys)
+        confidence.putContext(
+            context: ConfidenceTypeMapper.from(ctx: context),
+            removeKeys: removedKeys,
+            isProvider: true)
     }
 
     public func getBooleanEvaluation(key: String, defaultValue: Bool, context: EvaluationContext?) throws
     -> OpenFeature.ProviderEvaluation<Bool>
     {
-        try confidence.getEvaluation(key: key, defaultValue: defaultValue).toProviderEvaluation()
+        try confidence.getEvaluation(key: key, defaultValue: defaultValue, isProvider: true).toProviderEvaluation()
     }
 
     public func getStringEvaluation(key: String, defaultValue: String, context: EvaluationContext?) throws
     -> OpenFeature.ProviderEvaluation<String>
     {
-        try confidence.getEvaluation(key: key, defaultValue: defaultValue).toProviderEvaluation()
+        try confidence.getEvaluation(key: key, defaultValue: defaultValue, isProvider: true).toProviderEvaluation()
     }
 
     public func getIntegerEvaluation(key: String, defaultValue: Int64, context: EvaluationContext?) throws
     -> OpenFeature.ProviderEvaluation<Int64>
     {
-        try confidence.getEvaluation(key: key, defaultValue: defaultValue).toProviderEvaluation()
+        try confidence.getEvaluation(key: key, defaultValue: defaultValue, isProvider: true).toProviderEvaluation()
     }
 
     public func getDoubleEvaluation(key: String, defaultValue: Double, context: EvaluationContext?) throws
     -> OpenFeature.ProviderEvaluation<Double>
     {
-        try confidence.getEvaluation(key: key, defaultValue: defaultValue).toProviderEvaluation()
+        try confidence.getEvaluation(key: key, defaultValue: defaultValue, isProvider: true).toProviderEvaluation()
     }
 
     public func getObjectEvaluation(key: String, defaultValue: OpenFeature.Value, context: EvaluationContext?)
     throws -> OpenFeature.ProviderEvaluation<OpenFeature.Value>
     {
-        try confidence.getEvaluation(key: key, defaultValue: defaultValue).toProviderEvaluation()
+        try confidence.getEvaluation(key: key, defaultValue: defaultValue, isProvider: true).toProviderEvaluation()
     }
 
     public func observe() -> AnyPublisher<OpenFeature.ProviderEvent, Never> {

--- a/Tests/ConfidenceTests/ConfidenceFeatureProviderTest.swift
+++ b/Tests/ConfidenceTests/ConfidenceFeatureProviderTest.swift
@@ -52,7 +52,7 @@ class ConfidenceFeatureProviderTest: XCTestCase {
                 super.init(invocation: nil) // Workaround to use expectations in FakeClient
             }
 
-            func resolve(ctx: ConfidenceStruct) async throws -> ResolvesResult {
+            func resolve(ctx: ConfidenceStruct, isProvider: Bool) async throws -> ResolvesResult {
                 callCount += 1
                 switch callCount {
                 case 1:
@@ -114,7 +114,7 @@ class ConfidenceFeatureProviderTest: XCTestCase {
         class FakeClient: ConfidenceResolveClient {
             var resolveStats: Int = 0
             var resolvedValues: [ResolvedValue] = []
-            func resolve(ctx: ConfidenceStruct) async throws -> ResolvesResult {
+            func resolve(ctx: ConfidenceStruct, isProvider: Bool) async throws -> ResolvesResult {
                 self.resolveStats += 1
                 return .init(resolvedValues: resolvedValues, resolveToken: "token")
             }
@@ -172,7 +172,7 @@ class ConfidenceFeatureProviderTest: XCTestCase {
         class FakeClient: ConfidenceResolveClient {
             var resolveStats: Int = 0
             var resolvedValues: [ResolvedValue] = []
-            func resolve(ctx: ConfidenceStruct) async throws -> ResolvesResult {
+            func resolve(ctx: ConfidenceStruct, isProvider: Bool) async throws -> ResolvesResult {
                 self.resolveStats += 1
                 return .init(resolvedValues: resolvedValues, resolveToken: "token")
             }
@@ -214,7 +214,7 @@ class ConfidenceFeatureProviderTest: XCTestCase {
         class FakeClient: ConfidenceResolveClient {
             var resolveStats: Int = 0
             var resolvedValues: [ResolvedValue] = []
-            func resolve(ctx: ConfidenceStruct) async throws -> ResolvesResult {
+            func resolve(ctx: ConfidenceStruct, isProvider: Bool) async throws -> ResolvesResult {
                 self.resolveStats += 1
                 return .init(resolvedValues: resolvedValues, resolveToken: "token")
             }
@@ -254,7 +254,7 @@ class ConfidenceFeatureProviderTest: XCTestCase {
         class FakeClient: ConfidenceResolveClient {
             var resolveStats: Int = 0
             var resolvedValues: [ResolvedValue] = []
-            func resolve(ctx: ConfidenceStruct) async throws -> ResolvesResult {
+            func resolve(ctx: ConfidenceStruct, isProvider: Bool) async throws -> ResolvesResult {
                 self.resolveStats += 1
                 return .init(resolvedValues: resolvedValues, resolveToken: "token")
             }
@@ -299,7 +299,7 @@ class ConfidenceFeatureProviderTest: XCTestCase {
         class FakeClient: XCTestCase, ConfidenceResolveClient {
             var resolveStats: Int = 0
             var resolvedValues: [ResolvedValue] = []
-            func resolve(ctx: ConfidenceStruct) async throws -> ResolvesResult {
+            func resolve(ctx: ConfidenceStruct, isProvider: Bool) async throws -> ResolvesResult {
                 if self.resolveStats == 1 {
                     let expectation = expectation(description: "never fullfil")
                     await fulfillment(of: [expectation])
@@ -345,7 +345,7 @@ class ConfidenceFeatureProviderTest: XCTestCase {
         class FakeClient: ConfidenceResolveClient {
             var resolveStats: Int = 0
             var resolvedValues: [ResolvedValue] = []
-            func resolve(ctx: ConfidenceStruct) async throws -> ResolvesResult {
+            func resolve(ctx: ConfidenceStruct, isProvider: Bool) async throws -> ResolvesResult {
                 self.resolveStats += 1
                 return .init(resolvedValues: resolvedValues, resolveToken: "token")
             }
@@ -386,7 +386,7 @@ class ConfidenceFeatureProviderTest: XCTestCase {
         class FakeClient: ConfidenceResolveClient {
             var resolveStats: Int = 0
             var resolvedValues: [ResolvedValue] = []
-            func resolve(ctx: ConfidenceStruct) async throws -> ResolvesResult {
+            func resolve(ctx: ConfidenceStruct, isProvider: Bool) async throws -> ResolvesResult {
                 self.resolveStats += 1
                 return .init(resolvedValues: resolvedValues, resolveToken: "token")
             }
@@ -427,7 +427,7 @@ class ConfidenceFeatureProviderTest: XCTestCase {
         class FakeClient: ConfidenceResolveClient {
             var resolveStats: Int = 0
             var resolvedValues: [ResolvedValue] = []
-            func resolve(ctx: ConfidenceStruct) async throws -> ResolvesResult {
+            func resolve(ctx: ConfidenceStruct, isProvider: Bool) async throws -> ResolvesResult {
                 self.resolveStats += 1
                 return .init(resolvedValues: resolvedValues, resolveToken: "token")
             }
@@ -468,7 +468,7 @@ class ConfidenceFeatureProviderTest: XCTestCase {
         class FakeClient: ConfidenceResolveClient {
             var resolveStats: Int = 0
             var resolvedValues: [ResolvedValue] = []
-            func resolve(ctx: ConfidenceStruct) async throws -> ResolvesResult {
+            func resolve(ctx: ConfidenceStruct, isProvider: Bool) async throws -> ResolvesResult {
                 self.resolveStats += 1
                 return .init(resolvedValues: resolvedValues, resolveToken: "token")
             }
@@ -509,7 +509,7 @@ class ConfidenceFeatureProviderTest: XCTestCase {
         class FakeClient: ConfidenceResolveClient {
             var resolveStats: Int = 0
             var resolvedValues: [ResolvedValue] = []
-            func resolve(ctx: ConfidenceStruct) async throws -> ResolvesResult {
+            func resolve(ctx: ConfidenceStruct, isProvider: Bool) async throws -> ResolvesResult {
                 self.resolveStats += 1
                 return .init(resolvedValues: resolvedValues, resolveToken: "token")
             }
@@ -540,7 +540,7 @@ class ConfidenceFeatureProviderTest: XCTestCase {
         class FakeClient: ConfidenceResolveClient {
             var resolveStats: Int = 0
             var resolvedValues: [ResolvedValue] = []
-            func resolve(ctx: ConfidenceStruct) async throws -> ResolvesResult {
+            func resolve(ctx: ConfidenceStruct, isProvider: Bool) async throws -> ResolvesResult {
                 self.resolveStats += 1
                 return .init(resolvedValues: resolvedValues, resolveToken: "token")
             }

--- a/Tests/ConfidenceTests/Helpers/ClientMock.swift
+++ b/Tests/ConfidenceTests/Helpers/ClientMock.swift
@@ -17,7 +17,7 @@ class ClientMock: ConfidenceResolveClient {
         self.testMode = testMode
     }
 
-    func resolve(ctx: ConfidenceStruct) throws -> ResolvesResult {
+    func resolve(ctx: ConfidenceStruct, isProvider: Bool) throws -> ResolvesResult {
         return ResolvesResult(resolvedValues: [], resolveToken: "")
     }
 

--- a/Tests/ConfidenceTests/LocalStorageResolverTest.swift
+++ b/Tests/ConfidenceTests/LocalStorageResolverTest.swift
@@ -18,7 +18,7 @@ class LocalStorageResolverTest: XCTestCase {
 
         XCTAssertNoThrow(
             try flagResolution.evaluate(
-                flagName: "flag_name.string", defaultValue: "default", context: [:])
+                flagName: "flag_name.string", defaultValue: "default", context: [:], isProvider: false)
         )
     }
 
@@ -33,7 +33,11 @@ class LocalStorageResolverTest: XCTestCase {
         let flagResolution =
             FlagResolution(context: context, flags: [resolvedValue], resolveToken: "")
         XCTAssertThrowsError(
-            try flagResolution.evaluate(flagName: "new_flag_name", defaultValue: "default", context: context)
+            try flagResolution.evaluate(
+                flagName: "new_flag_name",
+                defaultValue: "default",
+                context: context,
+                isProvider: false)
         ) { error in
             XCTAssertEqual(
                 error as? ConfidenceError, .flagNotFoundError(key: "new_flag_name"))

--- a/Tests/ConfidenceTests/RemoteResolveConfidenceClientTest.swift
+++ b/Tests/ConfidenceTests/RemoteResolveConfidenceClientTest.swift
@@ -34,7 +34,7 @@ class RemoteResolveConfidenceClientTest: XCTestCase {
 
         let context = ["targeting_key": ConfidenceValue(string: "user1")]
 
-        let result = try await client.resolve(ctx: context)
+        let result = try await client.resolve(ctx: context, isProvider: false)
         XCTAssertEqual(result.resolvedValues.count, 2)
         let sortedResultValues = result.resolvedValues.sorted { resolvedValue1, resolvedValue2 in
             resolvedValue1.flag < resolvedValue2.flag


### PR DESCRIPTION
- This differentiation is not needed for **general events**, as their are (currently) only sent via CONFIDENCE.
- This works for resolve calls, but not for `apply` events: the latter are still hardcoded to using "CONFIDENCE" as SDK ID. 