### PR TITLE
fix: Confidence version auto-update

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -10,7 +10,8 @@
             "extra-files": [
                 "README.md",
                 "Sources/ConfidenceProvider/README.md",
-                "Sources/ConfidenceProvider/ConfidenceFeatureProvider.swift"
+                "Sources/ConfidenceProvider/ConfidenceFeatureProvider.swift",
+                "Sources/Confidence/Confidence.swift"
             ]
         }
     },


### PR DESCRIPTION
Not sure if we should bump manually the wrong version [here](https://github.com/spotify/confidence-sdk-swift/blob/54a674e7ff8be4c97ad296f6bf066b8641ae95b5/Sources/Confidence/Confidence.swift#L316), or release please will fix everything automatically on merge. I think the latter