### PR TITLE
docs: update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ Functionalities:
 - Automatic data collection about which flags have been accessed by the application
 - Event tracking for instrumenting your application
 
+### Swift 6 support: strict concurrency
+
+If your app is using some of the features of Swift 6, we recommend setting the **Strict Concurrency Checking** to 
+**Minimal**.
+
 ## Dependency Setup
 
 ### Swift Package Manager


### PR DESCRIPTION
This PR is updating README to document that current version of the SDK is compatible with Swift 6 given that the "Strict Concurrency" setting is set to "Minimal"