### PR TITLE
refactor!: getEvaluation doesnt throw

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ In the case of an error, the default value will be returned and the `Evaluation`
 
 ```swift
 let message: String = confidence.getValue(key: "flag-name.message", defaultValue: "default message") 
-let messageFlag: Evaluation<String> = try confidence.getEvaluation(key: "flag-name.message", defaultValue: "default message")
+let messageFlag: Evaluation<String> = confidence.getEvaluation(key: "flag-name.message", defaultValue: "default message")
 
 let messageValue = messageFlag.value
 // message and messageValue are the same

--- a/Sources/Confidence/Confidence.swift
+++ b/Sources/Confidence/Confidence.swift
@@ -126,8 +126,8 @@ public class Confidence: ConfidenceEventSender {
         }
     }
 
-    public func getEvaluation<T>(key: String, defaultValue: T) throws -> Evaluation<T> {
-        try self.cache.evaluate(
+    public func getEvaluation<T>(key: String, defaultValue: T) -> Evaluation<T> {
+        self.cache.evaluate(
             flagName: key,
             defaultValue: defaultValue,
             context: getContext(),
@@ -136,11 +136,7 @@ public class Confidence: ConfidenceEventSender {
     }
 
     public func getValue<T>(key: String, defaultValue: T) -> T {
-        do {
-            return try getEvaluation(key: key, defaultValue: defaultValue).value
-        } catch {
-            return defaultValue
-        }
+        return getEvaluation(key: key, defaultValue: defaultValue).value
     }
 
     func isStorageEmpty() -> Bool {

--- a/Sources/ConfidenceProvider/ConfidenceFeatureProvider.swift
+++ b/Sources/ConfidenceProvider/ConfidenceFeatureProvider.swift
@@ -92,31 +92,31 @@ public class ConfidenceFeatureProvider: FeatureProvider {
     public func getBooleanEvaluation(key: String, defaultValue: Bool, context: EvaluationContext?) throws
     -> OpenFeature.ProviderEvaluation<Bool>
     {
-        try confidence.getEvaluation(key: key, defaultValue: defaultValue).toProviderEvaluation()
+        confidence.getEvaluation(key: key, defaultValue: defaultValue).toProviderEvaluation()
     }
 
     public func getStringEvaluation(key: String, defaultValue: String, context: EvaluationContext?) throws
     -> OpenFeature.ProviderEvaluation<String>
     {
-        try confidence.getEvaluation(key: key, defaultValue: defaultValue).toProviderEvaluation()
+        confidence.getEvaluation(key: key, defaultValue: defaultValue).toProviderEvaluation()
     }
 
     public func getIntegerEvaluation(key: String, defaultValue: Int64, context: EvaluationContext?) throws
     -> OpenFeature.ProviderEvaluation<Int64>
     {
-        try confidence.getEvaluation(key: key, defaultValue: defaultValue).toProviderEvaluation()
+        confidence.getEvaluation(key: key, defaultValue: defaultValue).toProviderEvaluation()
     }
 
     public func getDoubleEvaluation(key: String, defaultValue: Double, context: EvaluationContext?) throws
     -> OpenFeature.ProviderEvaluation<Double>
     {
-        try confidence.getEvaluation(key: key, defaultValue: defaultValue).toProviderEvaluation()
+        confidence.getEvaluation(key: key, defaultValue: defaultValue).toProviderEvaluation()
     }
 
     public func getObjectEvaluation(key: String, defaultValue: OpenFeature.Value, context: EvaluationContext?)
     throws -> OpenFeature.ProviderEvaluation<OpenFeature.Value>
     {
-        try confidence.getEvaluation(key: key, defaultValue: defaultValue).toProviderEvaluation()
+        confidence.getEvaluation(key: key, defaultValue: defaultValue).toProviderEvaluation()
     }
 
     public func observe() -> AnyPublisher<OpenFeature.ProviderEvent, Never> {

--- a/Sources/ConfidenceProvider/ConfidenceFeatureProvider.swift
+++ b/Sources/ConfidenceProvider/ConfidenceFeatureProvider.swift
@@ -92,31 +92,31 @@ public class ConfidenceFeatureProvider: FeatureProvider {
     public func getBooleanEvaluation(key: String, defaultValue: Bool, context: EvaluationContext?) throws
     -> OpenFeature.ProviderEvaluation<Bool>
     {
-        confidence.getEvaluation(key: key, defaultValue: defaultValue).toProviderEvaluation()
+        try confidence.getEvaluation(key: key, defaultValue: defaultValue).toProviderEvaluation()
     }
 
     public func getStringEvaluation(key: String, defaultValue: String, context: EvaluationContext?) throws
     -> OpenFeature.ProviderEvaluation<String>
     {
-        confidence.getEvaluation(key: key, defaultValue: defaultValue).toProviderEvaluation()
+        try confidence.getEvaluation(key: key, defaultValue: defaultValue).toProviderEvaluation()
     }
 
     public func getIntegerEvaluation(key: String, defaultValue: Int64, context: EvaluationContext?) throws
     -> OpenFeature.ProviderEvaluation<Int64>
     {
-        confidence.getEvaluation(key: key, defaultValue: defaultValue).toProviderEvaluation()
+        try confidence.getEvaluation(key: key, defaultValue: defaultValue).toProviderEvaluation()
     }
 
     public func getDoubleEvaluation(key: String, defaultValue: Double, context: EvaluationContext?) throws
     -> OpenFeature.ProviderEvaluation<Double>
     {
-        confidence.getEvaluation(key: key, defaultValue: defaultValue).toProviderEvaluation()
+        try confidence.getEvaluation(key: key, defaultValue: defaultValue).toProviderEvaluation()
     }
 
     public func getObjectEvaluation(key: String, defaultValue: OpenFeature.Value, context: EvaluationContext?)
     throws -> OpenFeature.ProviderEvaluation<OpenFeature.Value>
     {
-        confidence.getEvaluation(key: key, defaultValue: defaultValue).toProviderEvaluation()
+        try confidence.getEvaluation(key: key, defaultValue: defaultValue).toProviderEvaluation()
     }
 
     public func observe() -> AnyPublisher<OpenFeature.ProviderEvent, Never> {
@@ -134,8 +134,20 @@ public class ConfidenceFeatureProvider: FeatureProvider {
 }
 
 extension Evaluation {
-    func toProviderEvaluation() -> ProviderEvaluation<T> {
-        ProviderEvaluation(
+    func toProviderEvaluation() throws -> ProviderEvaluation<T> {
+        if let errorCode = self.errorCode {
+            switch errorCode {
+            case .providerNotReady:
+                throw OpenFeatureError.providerNotReadyError
+            case .invalidContext:
+                throw OpenFeatureError.invalidContextError
+            case .flagNotFound:
+                throw OpenFeatureError.flagNotFoundError(key: self.errorMessage ?? "unknown key")
+            case .evaluationError:
+                throw OpenFeatureError.generalError(message: self.errorMessage ?? "unknown error")
+            }
+        }
+        return ProviderEvaluation(
             value: self.value,
             variant: self.variant,
             reason: self.reason.rawValue,

--- a/Tests/ConfidenceProviderTests/ConfidenceProviderTest.swift
+++ b/Tests/ConfidenceProviderTests/ConfidenceProviderTest.swift
@@ -7,10 +7,8 @@ import XCTest
 @testable import Confidence
 
 class ConfidenceProviderTest: XCTestCase {
-    private var readyExpectation = XCTestExpectation(description: "Ready")
-    private var errorExpectation = XCTestExpectation(description: "Error")
-
     func testErrorFetchOnInit() async throws {
+        let readyExpectation = XCTestExpectation(description: "Ready")
         class FakeClient: ConfidenceResolveClient {
             func resolve(ctx: ConfidenceStruct) async throws -> ResolvesResult {
                 throw ConfidenceError.internalError(message: "test")
@@ -28,7 +26,7 @@ class ConfidenceProviderTest: XCTestCase {
 
         let cancellable = OpenFeatureAPI.shared.observe().sink { event in
             if event == .ready {
-                self.readyExpectation.fulfill()
+                readyExpectation.fulfill()
             } else {
                 print(event)
             }
@@ -38,6 +36,7 @@ class ConfidenceProviderTest: XCTestCase {
     }
 
     func testErrorStorageOnInit() async throws {
+        let errorExpectation = XCTestExpectation(description: "Error")
         class FakeStorage: Storage {
             func save(data: Encodable) throws {
                 // no-op
@@ -66,12 +65,103 @@ class ConfidenceProviderTest: XCTestCase {
 
         let cancellable = OpenFeatureAPI.shared.observe().sink { event in
             if event == .error {
-                self.errorExpectation.fulfill()
+                errorExpectation.fulfill()
             } else {
                 print(event)
             }
         }
         await fulfillment(of: [errorExpectation], timeout: 5.0)
         cancellable.cancel()
+    }
+
+    func testProviderThrowsOpenFeatureErrors() async throws {
+        let context = MutableContext(targetingKey: "t")
+        let readyExpectation = XCTestExpectation(description: "Ready")
+        let storage = StorageMock()
+        class FakeClient: ConfidenceResolveClient {
+            var resolvedValues: [ResolvedValue] = [
+                ResolvedValue(
+                variant: "variant1",
+                value: .init(structure: ["int": .init(integer: 42)]),
+                flag: "flagName",
+                resolveReason: .match)
+            ]
+            func resolve(ctx: ConfidenceStruct) async throws -> ResolvesResult {
+                return .init(resolvedValues: resolvedValues, resolveToken: "token")
+            }
+        }
+
+        let confidence = Confidence.Builder(clientSecret: "test")
+            .withContext(initialContext: ["targeting_key": .init(string: "t")])
+            .withFlagResolverClient(flagResolver: FakeClient())
+            .withStorage(storage: storage)
+            .build()
+
+        let provider = ConfidenceFeatureProvider(confidence: confidence, initializationStrategy: .fetchAndActivate)
+        OpenFeatureAPI.shared.setProvider(provider: provider)
+        let cancellable = OpenFeatureAPI.shared.observe().sink { event in
+            if event == .ready {
+                readyExpectation.fulfill()
+            } else {
+                print(event)
+            }
+        }
+        await fulfillment(of: [readyExpectation], timeout: 1.0)
+        cancellable.cancel()
+        let evaluation = try provider.getIntegerEvaluation(key: "flagName.int", defaultValue: -1, context: context)
+        XCTAssertEqual(evaluation.value, 42)
+
+        XCTAssertThrowsError(try provider.getIntegerEvaluation(
+            key: "flagNotFound.something",
+            defaultValue: -1,
+            context: context))
+        { error in
+            if let specificError = error as? OpenFeatureError {
+                XCTAssertEqual(specificError.errorCode(), ErrorCode.flagNotFound)
+            } else {
+                XCTFail("expected a flag not found error")
+            }
+        }
+    }
+}
+
+private class StorageMock: Storage {
+    var data = ""
+    var saveExpectation: XCTestExpectation?
+    private let storageQueue = DispatchQueue(label: "com.confidence.storagemock")
+
+    convenience init(data: Encodable) throws {
+        self.init()
+        try self.save(data: data)
+    }
+
+    func save(data: Encodable) throws {
+        try storageQueue.sync {
+            let dataB = try JSONEncoder().encode(data)
+            self.data = String(decoding: dataB, as: UTF8.self)
+
+            saveExpectation?.fulfill()
+        }
+    }
+
+    func load<T>(defaultValue: T) throws -> T where T: Decodable {
+        try storageQueue.sync {
+            if data.isEmpty {
+                return defaultValue
+            }
+            return try JSONDecoder().decode(T.self, from: try XCTUnwrap(data.data(using: .utf8)))
+        }
+    }
+
+    func clear() throws {
+        storageQueue.sync {
+            data = ""
+        }
+    }
+
+    func isEmpty() -> Bool {
+        storageQueue.sync {
+            return data.isEmpty
+        }
     }
 }

--- a/Tests/ConfidenceTests/ConfidenceIntegrationTest.swift
+++ b/Tests/ConfidenceTests/ConfidenceIntegrationTest.swift
@@ -30,8 +30,8 @@ class ConfidenceIntegrationTests: XCTestCase {
             .withContext(initialContext: ctx)
             .build()
         try await confidence.fetchAndActivate()
-        let intResult = try confidence.getEvaluation(key: "\(resolveFlag).my-integer", defaultValue: "1")
-        let boolResult = try confidence.getEvaluation(key: "\(resolveFlag).my-boolean", defaultValue: false)
+        let intResult = confidence.getEvaluation(key: "\(resolveFlag).my-integer", defaultValue: "1")
+        let boolResult = confidence.getEvaluation(key: "\(resolveFlag).my-boolean", defaultValue: false)
 
 
         XCTAssertEqual(intResult.reason, .match)
@@ -104,7 +104,7 @@ class ConfidenceIntegrationTests: XCTestCase {
             .build()
         try await confidence.fetchAndActivate()
 
-        let result = try confidence.getEvaluation(key: "\(resolveFlag).my-integer", defaultValue: 1)
+        let result = confidence.getEvaluation(key: "\(resolveFlag).my-integer", defaultValue: 1)
 
         XCTAssertEqual(result.reason, .match)
         XCTAssertNotNil(result.variant)
@@ -132,7 +132,7 @@ class ConfidenceIntegrationTests: XCTestCase {
             .build()
         try await confidence.fetchAndActivate()
         // When evaluation of the flag happens using date context
-        let result = try confidence.getEvaluation(key: "\(resolveFlag).my-integer", defaultValue: 1)
+        let result = confidence.getEvaluation(key: "\(resolveFlag).my-integer", defaultValue: 1)
         // Then there is targeting match (non-default targeting)
         XCTAssertEqual(result.reason, .match)
         XCTAssertNotNil(result.variant)
@@ -162,7 +162,7 @@ class ConfidenceIntegrationTests: XCTestCase {
             .build()
         try await confidence.fetchAndActivate()
         // When evaluation of the flag happens using date context
-        let result = try confidence.getEvaluation(key: "\(resolveFlag).my-integer", defaultValue: 1)
+        let result = confidence.getEvaluation(key: "\(resolveFlag).my-integer", defaultValue: 1)
         // Then there is targeting match (non-default targeting)
         XCTAssertEqual(result.value, 1)
         XCTAssertEqual(result.reason, .noSegmentMatch)

--- a/Tests/ConfidenceTests/ConfidenceTest.swift
+++ b/Tests/ConfidenceTests/ConfidenceTest.swift
@@ -126,16 +126,13 @@ class ConfidenceTest: XCTestCase {
             .build()
 
         try await confidence.fetchAndActivate()
+        let emptyEvaluation = confidence.getEvaluation(
+            key: "flag.size",
+            defaultValue: "value"
+        )
 
-        XCTAssertThrowsError(
-            try confidence.getEvaluation(
-                key: "flag.size",
-                defaultValue: "value"
-            )) { error in
-                XCTAssertEqual(
-                    error as? ConfidenceError,
-                    ConfidenceError.flagNotFoundError(key: "flag"))
-        }
+        XCTAssertEqual(emptyEvaluation.value, "value")
+        XCTAssertEqual(emptyEvaluation.errorCode, .flagNotFound)
 
         client.resolvedValues = [
             ResolvedValue(
@@ -153,7 +150,7 @@ class ConfidenceTest: XCTestCase {
         await fulfillment(of: [expectation], timeout: 1)
         cancellable.cancel()
 
-        let evaluation = try confidence.getEvaluation(
+        let evaluation = confidence.getEvaluation(
             key: "flag.size",
             defaultValue: 0)
 
@@ -194,7 +191,7 @@ class ConfidenceTest: XCTestCase {
             .build()
 
         try await confidence.fetchAndActivate()
-        let evaluation = try confidence.getEvaluation(
+        let evaluation = confidence.getEvaluation(
             key: "flag.size",
             defaultValue: 0)
 
@@ -273,7 +270,7 @@ class ConfidenceTest: XCTestCase {
             .build()
 
         try await confidence.fetchAndActivate()
-        let evaluation = try confidence.getEvaluation(
+        let evaluation = confidence.getEvaluation(
             key: "flag.size",
             defaultValue: 0)
 
@@ -314,11 +311,11 @@ class ConfidenceTest: XCTestCase {
             .build()
 
         try await confidence.fetchAndActivate()
-        let evaluation = try confidence.getEvaluation(
+        let evaluation = confidence.getEvaluation(
             key: "flag.size",
             defaultValue: 0)
 
-        _ = try confidence.getEvaluation(
+        _ = confidence.getEvaluation(
             key: "flag.size",
             defaultValue: 0)
 
@@ -364,7 +361,7 @@ class ConfidenceTest: XCTestCase {
 
         try await confidence.fetchAndActivate()
         confidence.putContext(context: ["hello": .init(string: "world")])
-        let evaluation = try confidence.getEvaluation(
+        let evaluation = confidence.getEvaluation(
             key: "flag.size",
             defaultValue: 0)
 
@@ -405,7 +402,7 @@ class ConfidenceTest: XCTestCase {
             .build()
 
         try await confidence.fetchAndActivate()
-        let evaluation = try confidence.getEvaluation(
+        let evaluation = confidence.getEvaluation(
             key: "flag.size",
             defaultValue: 0.0)
 
@@ -446,7 +443,7 @@ class ConfidenceTest: XCTestCase {
             .build()
 
         try await confidence.fetchAndActivate()
-        let evaluation = try confidence.getEvaluation(
+        let evaluation = confidence.getEvaluation(
             key: "flag.size",
             defaultValue: false)
 
@@ -487,7 +484,7 @@ class ConfidenceTest: XCTestCase {
             .build()
 
         try await confidence.fetchAndActivate()
-        let evaluation = try confidence.getEvaluation(
+        let evaluation = confidence.getEvaluation(
             key: "flag.size",
             defaultValue: [:])
 
@@ -528,7 +525,7 @@ class ConfidenceTest: XCTestCase {
             .build()
 
         try await confidence.fetchAndActivate()
-        let evaluation = try confidence.getEvaluation(
+        let evaluation = confidence.getEvaluation(
             key: "flag.size",
             defaultValue: 42)
 
@@ -543,7 +540,7 @@ class ConfidenceTest: XCTestCase {
         XCTAssertEqual(flagApplier.applyCallCount, 1)
     }
 
-    func testProviderThrowsFlagNotFound() async throws {
+    func testProviderFlagNotFound() async throws {
         class FakeClient: ConfidenceResolveClient {
             var resolveStats: Int = 0
             var resolvedValues: [ResolvedValue] = []
@@ -562,15 +559,16 @@ class ConfidenceTest: XCTestCase {
             .build()
 
         try await confidence.fetchAndActivate()
-        XCTAssertThrowsError(
-            try confidence.getEvaluation(
-                key: "flag.size",
-                defaultValue: 42
-            )
-        ) { error in
-            XCTAssertEqual(error as? ConfidenceError, ConfidenceError.flagNotFoundError(key: "flag"))
-        }
+        let evaluation = confidence.getEvaluation(
+            key: "flag.size",
+            defaultValue: 42
+        )
 
+        XCTAssertEqual(evaluation.value, 42)
+        XCTAssertNil(evaluation.variant)
+        XCTAssertEqual(evaluation.reason, .error)
+        XCTAssertEqual(evaluation.errorCode, .flagNotFound)
+        XCTAssertEqual(evaluation.errorMessage, "Flag 'flag' not found in local cache")
         XCTAssertEqual(client.resolveStats, 1)
     }
 
@@ -595,7 +593,7 @@ class ConfidenceTest: XCTestCase {
             .build()
 
         try await confidence.fetchAndActivate()
-        let evaluation = try confidence.getEvaluation(
+        let evaluation = confidence.getEvaluation(
             key: "flag.size",
             defaultValue: 42)
 

--- a/Tests/ConfidenceTests/LocalStorageResolverTest.swift
+++ b/Tests/ConfidenceTests/LocalStorageResolverTest.swift
@@ -17,7 +17,7 @@ class LocalStorageResolverTest: XCTestCase {
         )
 
         XCTAssertNoThrow(
-            try flagResolution.evaluate(
+            flagResolution.evaluate(
                 flagName: "flag_name.string", defaultValue: "default", context: [:])
         )
     }
@@ -30,13 +30,12 @@ class LocalStorageResolverTest: XCTestCase {
         )
         let context =
             ["hey": ConfidenceValue(string: "old value")]
-        let flagResolution =
-            FlagResolution(context: context, flags: [resolvedValue], resolveToken: "")
-        XCTAssertThrowsError(
-            try flagResolution.evaluate(flagName: "new_flag_name", defaultValue: "default", context: context)
-        ) { error in
-            XCTAssertEqual(
-                error as? ConfidenceError, .flagNotFoundError(key: "new_flag_name"))
-        }
+        let flagResolution = FlagResolution(context: context, flags: [resolvedValue], resolveToken: "")
+        let evaluation = flagResolution.evaluate(flagName: "new_flag_name", defaultValue: "default", context: context)
+        XCTAssertEqual(evaluation.value, "default")
+        XCTAssertNil(evaluation.variant)
+        XCTAssertEqual(evaluation.reason, .error)
+        XCTAssertEqual(evaluation.errorCode, .flagNotFound)
+        XCTAssertEqual(evaluation.errorMessage, "Flag 'new_flag_name' not found in local cache")
     }
 }

--- a/api/Confidence_public_api.json
+++ b/api/Confidence_public_api.json
@@ -16,7 +16,7 @@
       },
       {
         "name": "getEvaluation(key:defaultValue:)",
-        "declaration": "public func getEvaluation<T>(key: String, defaultValue: T) throws -> Evaluation<T>"
+        "declaration": "public func getEvaluation<T>(key: String, defaultValue: T) -> Evaluation<T>"
       },
       {
         "name": "getValue(key:defaultValue:)",


### PR DESCRIPTION
It's not consistent if some errors are returned via `errorCode` and `errorMessage` fields and other errors (i.e. flagNotFound) are handled via throwing.

This is also the behaviour in OpenFeature.

- [x] We need to make sure errors are propagated correctly to OpenFeature in `toProviderEvaluation()`