### PR TITLE
test: date formatter in tests iOS18

### DIFF
--- a/Tests/ConfidenceProviderTests/ConfidenceTypeMapperTest.swift
+++ b/Tests/ConfidenceProviderTests/ConfidenceTypeMapperTest.swift
@@ -64,6 +64,7 @@ class ValueConverterTest: XCTestCase {
 
     func testContextConversionWithLists() throws {
         let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
         formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
         let date1 = try XCTUnwrap(formatter.date(from: "2022-01-01 12:00:00"))
         let date2 = try XCTUnwrap(formatter.date(from: "2022-01-02 12:00:00"))
@@ -112,6 +113,7 @@ class ValueConverterTest: XCTestCase {
 
     func testValueConversion() throws {
         let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
         formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
         let date = try XCTUnwrap(formatter.date(from: "2022-01-01 12:00:00"))
 

--- a/Tests/ConfidenceTests/ConfidenceIntegrationTest.swift
+++ b/Tests/ConfidenceTests/ConfidenceIntegrationTest.swift
@@ -178,6 +178,7 @@ class ConfidenceIntegrationTests: XCTestCase {
 
     private func convertStringToDate(_ dateString: String) -> Date? {
         let dateFormatter = DateFormatter()
+        dateFormatter.locale = Locale(identifier: "en_US_POSIX")
         dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZ"
         return dateFormatter.date(from: dateString)
     }

--- a/Tests/ConfidenceTests/ConfidenceValueTests.swift
+++ b/Tests/ConfidenceTests/ConfidenceValueTests.swift
@@ -29,6 +29,7 @@ final class ConfidenceConfidenceValueTests: XCTestCase {
 
     func testStringShouldConvertToDate() throws {
         let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
         formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
         let date = try XCTUnwrap(formatter.date(from: "2022-01-01 12:00:00"))
         let value = ConfidenceValue(timestamp: date)
@@ -43,6 +44,7 @@ final class ConfidenceConfidenceValueTests: XCTestCase {
 
     func testListShouldConvertToList() throws {
         let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
         formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
         formatter.timeZone = TimeZone(abbreviation: "UTC")
         let date1 = try XCTUnwrap(formatter.date(from: "2022-01-01 12:00:00"))
@@ -106,6 +108,7 @@ final class ConfidenceConfidenceValueTests: XCTestCase {
 
     func testEncodeDecode() throws {
         let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
         formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
         formatter.timeZone = TimeZone(abbreviation: "EDT") // Verify TimeZone conversion
         let date = try XCTUnwrap(formatter.date(from: "2024-04-05 16:00:00"))

--- a/Tests/ConfidenceTests/TypeMapperTests.swift
+++ b/Tests/ConfidenceTests/TypeMapperTests.swift
@@ -38,6 +38,7 @@ class TypeMapperTests: XCTestCase {
 
     func testConfidenceToNetwork() throws {
         let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
         formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
         formatter.timeZone = TimeZone.init(identifier: "UTC+01")
         let date = try XCTUnwrap(formatter.date(from: "2022-01-01 12:00:00"))


### PR DESCRIPTION
These tests started failing on iOS18. It must be something that has changed in the Apple ecosystem, although I haven't found the exact culprit yet. Nevertheless, specifying the locale is still good practice, and it makes the tests green.

Note that the main code (not the test code), is setting locale already: https://github.com/spotify/confidence-sdk-swift/blob/448fb930e869d8282566f5c1abfa147a1a6611e9/Sources/Confidence/Backport.swift#L64