### PR TITLE
fix: TypeMismatch error is handled

### DIFF
--- a/Sources/Confidence/FlagEvaluation.swift
+++ b/Sources/Confidence/FlagEvaluation.swift
@@ -85,6 +85,7 @@ extension FlagResolution {
                         errorMessage: nil
                     )
                 } else {
+                    // `null` type from backend instructs to use client-side default value
                     if parsedValue == .init(null: ()) {
                         return Evaluation(
                             value: defaultValue,

--- a/Sources/ConfidenceProvider/ConfidenceFeatureProvider.swift
+++ b/Sources/ConfidenceProvider/ConfidenceFeatureProvider.swift
@@ -145,6 +145,8 @@ extension Evaluation {
                 throw OpenFeatureError.flagNotFoundError(key: self.errorMessage ?? "unknown key")
             case .evaluationError:
                 throw OpenFeatureError.generalError(message: self.errorMessage ?? "unknown error")
+            case .typeMismatch:
+                throw OpenFeatureError.typeMismatchError
             }
         }
         return ProviderEvaluation(

--- a/Tests/ConfidenceTests/ConfidenceIntegrationTest.swift
+++ b/Tests/ConfidenceTests/ConfidenceIntegrationTest.swift
@@ -30,7 +30,7 @@ class ConfidenceIntegrationTests: XCTestCase {
             .withContext(initialContext: ctx)
             .build()
         try await confidence.fetchAndActivate()
-        let intResult = confidence.getEvaluation(key: "\(resolveFlag).my-integer", defaultValue: "1")
+        let intResult = confidence.getEvaluation(key: "\(resolveFlag).my-integer", defaultValue: 1)
         let boolResult = confidence.getEvaluation(key: "\(resolveFlag).my-boolean", defaultValue: false)
 
 


### PR DESCRIPTION
This is an important fix to signal users that the returned value is the default value due to a type mismatch, rather than looking like the variant's value returned by the backend.

This happens when the user tries to get a value with a type that is not the the same type defined in the backend schema for that value.