### PR TITLE
docs: Spec putContext / track(ConfidenceContextProducer)

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,8 @@ It is also appended to the tracked events, making it a great way to create dimen
 confidence.putContext(context: ["key": ConfidenceValue(string: "value")])
 ```
 
-Note that a `ConfidenceValue` is accepted a map values, which has a constructor for all the value types
-supported by Confidence.
+Upon the returning of this function call, the updated context is appended to tracking events.
+However, to relfect the new context in flags resolves, a new call to `fetchAndActivate()` is required.
 
 ### Resolving feature flags
 Once the Confidence instance is **activated**, you can access the flag values using the

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ To avoid waiting on backend calls when the Application starts, the suggested app
 `confidence.activate()` and then trigger a background refresh via `confidence.asyncFetch()` for future sessions.
 
 ### Setting the context
-The context is a key-value map used for sampling and for targeting, when flag are evaluated by the Confidence backend.
+The context is a key-value map used for sampling and for targeting, when flags are evaluated by the Confidence backend.
 It is also appended to the tracked events, making it a great way to create dimensions for metrics in Confidence.
 
 ```swift
@@ -86,9 +86,9 @@ confidence.track(producer: contextProducerImplementation)
 The "producer" conforms to `ConfidenceContextProducer`, which allows to dynamically push context changes
 to the Confidence object.
 
-In both cases above, any context change triggers a new `fetchAndActivate` asynchronously and the flags in the
-local cache are re-evaluated remotely according to the new context: until that background operation is complete,
-flag values are returned to the application according to the old context's evaluation, and marked as "stale".
+In both cases above, any context change triggers a new asynchronous `fetchAndActivate` and the flags in the
+local cache are re-evaluated remotely according to the new context: until this background operation is complete,
+flag values are returned to the application according to the old context's evaluation, and with `resolveReason = .stale`.
 
 
 ### Resolving feature flags

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ confidence.putContext(context: ["key": ConfidenceValue(string: "value")])
 ```
 
 Upon the returning of this function call, the updated context is appended to tracking events.
-However, to relfect the new context in flags resolves, a new call to `fetchAndActivate()` is required.
+However, to reflect the new context in flags resolves, a new call to `fetchAndActivate()` is required.
 
 ### Resolving feature flags
 Once the Confidence instance is **activated**, you can access the flag values using the

--- a/README.md
+++ b/README.md
@@ -78,8 +78,18 @@ It is also appended to the tracked events, making it a great way to create dimen
 confidence.putContext(context: ["key": ConfidenceValue(string: "value")])
 ```
 
-Upon the returning of this function call, the updated context is appended to tracking events.
-However, to reflect the new context in flags resolves, a new call to `fetchAndActivate()` is required.
+Another way to configure the context involves using the `track` API:
+```swift
+confidence.track(producer: contextProducerImplementation)
+```
+
+The "producer" conforms to `ConfidenceContextProducer`, which allows to dynamically push context changes
+to the Confidence object.
+
+In both cases above, any context change triggers a new `fetchAndActivate` asynchronously and the flags in the
+local cache are re-evaluated remotely according to the new context: until that background operation is complete,
+flag values are returned to the application according to the old context's evaluation, and marked as "stale".
+
 
 ### Resolving feature flags
 Once the Confidence instance is **activated**, you can access the flag values using the


### PR DESCRIPTION
### Observation 1
From the DemoApp:
```
@StateObject private var lifecycleObserver: ConfidenceContextProducer = ConfidenceAppLifecycleProducer()
...
let confidence = Confidence.Builder(...).build()
confidence.track(producer: lifecycleObserver) // triggers fetchAndActivate
...
try await confidence.fetchAndActivate() // the app calls fetchAndActivate
```

The ideal situation would be to have a single `fetchAndActivate` call, and the ability to await an async function to make sure the flags are fresh and ready in the cache. However, our current API portfolio doesn't seem to allow for both of those things together.

### Observation 2
Code snippet [here](https://github.com/spotify/confidence-sdk-swift/pull/169/files#diff-ce4b02dd34ba8eb8e8e68dee451e2246f2dff4793577cb5a1abbc6ecd2c9e571R41-R46).

Today it's impossible to have a setup where the context is changed and the UI showing a loading indicator until the resolve is complete, while at the same time having a single `fetchAndActivate` call for each context change.

## Possible improvements
- Confidence builder accept a list of ContextProducers, and applies the context from them for the first time _without_ calling fetchAndActivate
- `putContext` is made async: users can wait for the new flags to be ready before reading values (this is probably harder to achieve with the ContextProducer solution)
