### PR TITLE
fix: Align debug resolve log wording on all platforms

### DIFF
--- a/Sources/Confidence/DebugLogger.swift
+++ b/Sources/Confidence/DebugLogger.swift
@@ -32,7 +32,10 @@ internal class DebugLoggerImpl: DebugLogger {
                 URLQueryItem(name: "flag", value: "flags/\(flagName)"),
                 URLQueryItem(name: "context", value: "\(ctxNetworkString)"),
             ]
-            log(messageLevel: .DEBUG, message: "[Resolve Debug] \(url.url?.absoluteString ?? "N/A")")
+            log(messageLevel: .DEBUG, message: """
+                See resolves for \(flagName) in Confidence:
+                \(url.url?.absoluteString ?? "N/A")
+            """)
         }
     }
 


### PR DESCRIPTION
Updates the wording in logger