### PR TITLE
feat: Adopt latest OF SDK

### DIFF
--- a/ConfidenceDemoApp/ConfidenceDemoApp.xcodeproj/project.pbxproj
+++ b/ConfidenceDemoApp/ConfidenceDemoApp.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		733219BF2BE3C11100747AC2 /* ConfidenceOpenFeature in Frameworks */ = {isa = PBXBuildFile; productRef = 733219BE2BE3C11100747AC2 /* ConfidenceOpenFeature */; };
+		734EBDDC2D565CAC006D3435 /* Confidence in Frameworks */ = {isa = PBXBuildFile; productRef = 734EBDDB2D565CAC006D3435 /* Confidence */; };
 		735EADF52CF9B64E007BC42C /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 735EADF42CF9B64E007BC42C /* LoginView.swift */; };
 		C770C99A2A739FBC00C2AC8C /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C770C9962A739FBC00C2AC8C /* Preview Assets.xcassets */; };
 		C770C99B2A739FBC00C2AC8C /* ConfidenceDemoApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = C770C9972A739FBC00C2AC8C /* ConfidenceDemoApp.swift */; };
@@ -56,7 +56,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				733219BF2BE3C11100747AC2 /* ConfidenceOpenFeature in Frameworks */,
+				734EBDDC2D565CAC006D3435 /* Confidence in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -169,7 +169,7 @@
 			);
 			name = ConfidenceDemoApp;
 			packageProductDependencies = (
-				733219BE2BE3C11100747AC2 /* ConfidenceOpenFeature */,
+				734EBDDB2D565CAC006D3435 /* Confidence */,
 			);
 			productName = ConfidenceDemoApp;
 			productReference = C770C9682A739FA000C2AC8C /* ConfidenceDemoApp.app */;
@@ -646,9 +646,9 @@
 /* End XCConfigurationList section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		733219BE2BE3C11100747AC2 /* ConfidenceOpenFeature */ = {
+		734EBDDB2D565CAC006D3435 /* Confidence */ = {
 			isa = XCSwiftPackageProductDependency;
-			productName = ConfidenceOpenFeature;
+			productName = Confidence;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/ConfidenceDemoApp/ConfidenceDemoApp/ConfidenceDemoApp.swift
+++ b/ConfidenceDemoApp/ConfidenceDemoApp/ConfidenceDemoApp.swift
@@ -26,7 +26,7 @@ struct ConfidenceDemoApp: App {
             withAppInfo: true,
             withOsInfo: true,
             withLocale: true
-        ).decorated(context: [:]);
+        ).decorated(context: context);
 
         confidence = Confidence
             .Builder(clientSecret: secret, loggerLevel: .TRACE)

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "git@github.com:open-feature/swift-sdk.git",
         "state": {
           "branch": null,
-          "revision": "02b033c954766e86d5706bfc8ee5248244c11e77",
-          "version": "0.1.0"
+          "revision": "e2be5852827d7d6b837b9a4e577bb52bea6322d7",
+          "version": "0.3.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
             targets: ["Confidence"])
     ],
     dependencies: [
-        .package(url: "git@github.com:open-feature/swift-sdk.git", from: "0.1.0"),
+        .package(url: "git@github.com:open-feature/swift-sdk.git", from: "0.3.0"),
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
             targets: ["Confidence"])
     ],
     dependencies: [
-        .package(url: "git@github.com:open-feature/swift-sdk.git", from: "0.3.0"),
+        .package(url: "git@github.com:open-feature/swift-sdk.git", .exact("0.3.0")),
     ],
     targets: [
         .target(

--- a/api/ConfidenceProvider_public_api.json
+++ b/api/ConfidenceProvider_public_api.json
@@ -8,11 +8,11 @@
       },
       {
         "name": "initialize(initialContext:)",
-        "declaration": "public func initialize(initialContext: OpenFeature.EvaluationContext?)"
+        "declaration": "public func initialize(initialContext: OpenFeature.EvaluationContext?) async throws"
       },
       {
         "name": "onContextSet(oldContext:newContext:)",
-        "declaration": "public func onContextSet(\n    oldContext: OpenFeature.EvaluationContext?,\n    newContext: OpenFeature.EvaluationContext\n)"
+        "declaration": "public func onContextSet(\n    oldContext: OpenFeature.EvaluationContext?,\n    newContext: OpenFeature.EvaluationContext\n) async"
       },
       {
         "name": "getBooleanEvaluation(key:defaultValue:context:)",
@@ -36,7 +36,7 @@
       },
       {
         "name": "observe()",
-        "declaration": "public func observe() -> AnyPublisher<OpenFeature.ProviderEvent, Never>"
+        "declaration": "public func observe() -> AnyPublisher<OpenFeature.ProviderEvent?, Never>"
       }
     ]
   }


### PR DESCRIPTION
Events are removed, since now handled automatically by the underlying SDK. onContextSet is now awaiting, returning on success or throwing on failure, as expected by the new SDK version.