### PR TITLE
fix: Better error reporting for structure evaluations

### DIFF
--- a/Sources/Confidence/ConfidenceError.swift
+++ b/Sources/Confidence/ConfidenceError.swift
@@ -9,6 +9,28 @@ public enum ConfidenceError: Error, Equatable {
     case internalError(message: String)
     case parseError(message: String)
     case invalidContextInMessage
+
+    var errorCode: ErrorCode {
+        switch self {
+        case .grpcError(let message),
+            .cacheError(let message),
+            .corruptedCache(let message),
+            .badRequest(let message?),
+            .internalError(let message):
+            return .generalError(message: message)
+
+        case .flagNotFoundError:
+            return .flagNotFound
+
+        case .parseError(let message):
+            return .parseError(message: message)
+
+        case .invalidContextInMessage:
+            return .invalidContext
+        case .badRequest(message: .none):
+            return .generalError(message: "unknown error")
+        }
+    }
 }
 
 extension ConfidenceError: CustomStringConvertible {

--- a/Sources/ConfidenceProvider/ConfidenceFeatureProvider.swift
+++ b/Sources/ConfidenceProvider/ConfidenceFeatureProvider.swift
@@ -99,6 +99,7 @@ public class ConfidenceFeatureProvider: FeatureProvider {
     public func getObjectEvaluation(key: String, defaultValue: OpenFeature.Value, context: EvaluationContext?)
     throws -> OpenFeature.ProviderEvaluation<OpenFeature.Value>
     {
+        // Convert Struct Value to 
         try confidence.getEvaluation(key: key, defaultValue: defaultValue).toProviderEvaluation()
     }
 
@@ -130,6 +131,10 @@ extension Evaluation {
                 throw OpenFeatureError.generalError(message: self.errorMessage ?? "unknown error")
             case .typeMismatch:
                 throw OpenFeatureError.typeMismatchError
+            case .parseError(message: let message):
+                throw OpenFeatureError.parseError(message: message)
+            case .generalError(message: let message):
+                throw OpenFeatureError.generalError(message: message)
             }
         }
         return ProviderEvaluation(


### PR DESCRIPTION
Returning `parseError` in case of unsupported resolving of `Value "structure"` from the OpenFeature Provider. Same for `ConfidenceValue "structure"`. 

The related error message is also clearer now:
```
Flag path must contain path to the field for non-object values
```

Related to #190 