### PR TITLE
feat: pass Decodable struct to flag evaluation

### DIFF
--- a/Sources/Confidence/Confidence.swift
+++ b/Sources/Confidence/Confidence.swift
@@ -119,7 +119,7 @@ public class Confidence: ConfidenceEventSender {
     - Parameter key:expects dot-notation to retrieve a specific entry in the flag's value, e.g. "flagname.myentry"
     - Parameter defaultValue: returned in case of errors or in case of the variant's rule indicating to use the default value.
     */
-    public func getEvaluation<T>(key: String, defaultValue: T) -> Evaluation<T> {
+    public func getEvaluation<T: Decodable>(key: String, defaultValue: T) -> Evaluation<T> {
         cacheQueue.sync {  [weak self] in
             guard let self = self else {
                 return Evaluation(
@@ -145,7 +145,7 @@ public class Confidence: ConfidenceEventSender {
     - Parameter key:expects dot-notation to retrieve a specific entry in the flag's value, e.g. "flagname.myentry"
     - Parameter defaultValue: returned in case of errors or in case of the variant's rule indicating to use the default value.
     */
-    public func getValue<T>(key: String, defaultValue: T) -> T {
+    public func getValue<T: Decodable>(key: String, defaultValue: T) -> T {
         return getEvaluation(key: key, defaultValue: defaultValue).value
     }
 

--- a/Sources/Confidence/ConfidenceValue.swift
+++ b/Sources/Confidence/ConfidenceValue.swift
@@ -211,6 +211,9 @@ extension ConfidenceValue {
 }
 
 extension ConfidenceValue {
+    // swiftlint:disable function_body_length
+    // swiftlint:disable cyclomatic_complexity
+    // swiftlint:disable identifier_name
     public func asJSONData() -> Data? {
         let encoder = JSONEncoder()
         encoder.outputFormatting = .sortedKeys
@@ -276,6 +279,9 @@ extension ConfidenceValue {
             return nil
         }
     }
+    // swiftlint:enable function_body_length
+    // swiftlint:enable cyclomatic_complexity
+    // swiftlint:enable identifier_name
 }
 
 

--- a/Sources/Confidence/ConfidenceValue.swift
+++ b/Sources/Confidence/ConfidenceValue.swift
@@ -210,6 +210,75 @@ extension ConfidenceValue {
     }
 }
 
+extension ConfidenceValue {
+    public func asJSONData() -> Data? {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .sortedKeys
+
+        switch value {
+        case .boolean(let value):
+            return try? encoder.encode(value)
+        case .string(let value):
+            return try? encoder.encode(value)
+        case .integer(let value):
+            return try? encoder.encode(value)
+        case .double(let value):
+            return try? encoder.encode(value)
+        case .date(let value):
+            return try? encoder.encode(value)
+        case .timestamp(let value):
+            return try? encoder.encode(value)
+        case .structure(let values):
+            var flattened: [String: Any] = [:]
+            for (key, value) in values {
+                switch value {
+                case .boolean(let v): flattened[key] = v
+                case .string(let v): flattened[key] = v
+                case .integer(let v): flattened[key] = v
+                case .double(let v): flattened[key] = v
+                case .date(let v): flattened[key] = v
+                case .timestamp(let v): flattened[key] = v
+                case .structure(let v):
+                    var nested: [String: Any] = [:]
+                    for (nestedKey, nestedValue) in v {
+                        switch nestedValue {
+                        case .boolean(let v): nested[nestedKey] = v
+                        case .string(let v): nested[nestedKey] = v
+                        case .integer(let v): nested[nestedKey] = v
+                        case .double(let v): nested[nestedKey] = v
+                        case .date(let v): nested[nestedKey] = v
+                        case .timestamp(let v): nested[nestedKey] = v
+                        case .structure(let v):
+                            var innerNested: [String: Any] = [:]
+                            for (innerKey, innerValue) in v {
+                                switch innerValue {
+                                case .boolean(let v): innerNested[innerKey] = v
+                                case .string(let v): innerNested[innerKey] = v
+                                case .integer(let v): innerNested[innerKey] = v
+                                case .double(let v): innerNested[innerKey] = v
+                                case .date(let v): innerNested[innerKey] = v
+                                case .timestamp(let v): innerNested[innerKey] = v
+                                default: break
+                                }
+                            }
+                            nested[nestedKey] = innerNested
+                        default: break
+                        }
+                    }
+                    flattened[key] = nested
+                default: break
+                }
+            }
+            return try? JSONSerialization.data(withJSONObject: flattened, options: .sortedKeys)
+        case .null:
+            return try? JSONSerialization.data(withJSONObject: NSNull())
+        default:
+            return nil
+        }
+    }
+}
+
+
 public enum ConfidenceValueType: CaseIterable {
     case boolean
     case string

--- a/Sources/Confidence/FlagEvaluation.swift
+++ b/Sources/Confidence/FlagEvaluation.swift
@@ -140,7 +140,7 @@ extension FlagResolution {
             )
         }
     }
-    
+
     // swiftlint:enable function_body_length
     // swiftlint:enable cyclomatic_complexity
     private func checkBackendErrors<T>(resolvedFlag: ResolvedValue, defaultValue: T) -> Evaluation<T>? {
@@ -153,8 +153,8 @@ extension FlagResolution {
                 errorMessage: "Invalid targeting key"
             )
         } else if resolvedFlag.resolveReason == .error ||
-                  resolvedFlag.resolveReason == .unknown ||
-                  resolvedFlag.resolveReason == .unspecified {
+            resolvedFlag.resolveReason == .unknown ||
+            resolvedFlag.resolveReason == .unspecified {
             return Evaluation(
                 value: defaultValue,
                 variant: nil,
@@ -210,25 +210,24 @@ extension FlagResolution {
 
     private func tryDecodeCodable<T>(value: ConfidenceValue, debugLogger: DebugLogger?) -> T? {
         guard let decodable = T.self as? Decodable.Type else {
-            debugLogger?.logMessage(message: "tryDecodeCodable: Type \(T.self) does not conform to Decodable", isWarning: true)
+            debugLogger?.logMessage(
+                message: "tryDecodeCodable: Type \(T.self) does not conform to Decodable",
+                isWarning: true)
             return nil
         }
 
         guard let data = value.asJSONData() else {
-            debugLogger?.logMessage(message: "tryDecodeCodable: Failed to encode ConfidenceValue to JSON", isWarning: true)
+            debugLogger?.logMessage(
+                message: "tryDecodeCodable: Failed to encode ConfidenceValue to JSON",
+                isWarning: true)
             return nil
         }
-/*
-        if let jsonString = String(data: data, encoding: .utf8) {
-            debugLogger?.logMessage(message: "tryDecodeCodable: Encoded JSON: \(jsonString)")
-        } else {
-            debugLogger?.logMessage(message: "tryDecodeCodable: Failed to convert encoded data to string")
-        }
-*/
         do {
             let decoded = try JSONDecoder().decode(decodable, from: data) as? T
             if decoded == nil {
-                debugLogger?.logMessage(message: "tryDecodeCodable: Failed to cast decoded value to type \(T.self)", isWarning: true)
+                debugLogger?.logMessage(
+                    message: "tryDecodeCodable: Failed to cast decoded value to type \(T.self)",
+                    isWarning: true)
             }
             return decoded
         } catch {

--- a/Tests/ConfidenceTests/ConfidenceTest.swift
+++ b/Tests/ConfidenceTests/ConfidenceTest.swift
@@ -240,6 +240,92 @@ class ConfidenceTest: XCTestCase {
         XCTAssertEqual(flagApplier.applyCallCount, 1)
     }
 
+    func testResolveObjectFlagWithUnderlyingStruct() async throws {
+        class FakeClient: ConfidenceResolveClient {
+            var resolveStats: Int = 0
+            var resolvedValues: [ResolvedValue] = []
+            func resolve(ctx: ConfidenceStruct) async throws -> ResolvesResult {
+                self.resolveStats += 1
+                return .init(resolvedValues: resolvedValues, resolveToken: "token")
+            }
+        }
+
+        let expected: ConfidenceValue = .init(structure: ["blob": .init(structure: ["size": .init(integer: 3), "name": .init(string: "testInner")]), "string": .init(string: "test")])
+        let client = FakeClient()
+        client.resolvedValues = [
+            ResolvedValue(
+                variant: "control",
+                value: expected,
+                flag: "flag",
+                resolveReason: .match,
+                shouldApply: false)
+        ]
+
+        let confidence = Confidence.Builder(clientSecret: "test")
+            .withContext(initialContext: ["targeting_key": .init(string: "user2")])
+            .withFlagResolverClient(flagResolver: client)
+            .withFlagApplier(flagApplier: flagApplier)
+            .build()
+
+        try await confidence.fetchAndActivate()
+
+        // if the expected output is a struct, it's important the the defaultValue is ConfidenceStruct.
+        let defaultValue = ConfidenceStruct(uniqueKeysWithValues: [])
+        let evaluation = confidence.getValue(
+            key: "flag",
+            defaultValue: defaultValue)
+
+        XCTAssertEqual(evaluation, expected.asStructure())
+    }
+
+
+    func testResolveCodable() async throws {
+        class FakeClient: ConfidenceResolveClient {
+            var resolveStats: Int = 0
+            var resolvedValues: [ResolvedValue] = []
+            func resolve(ctx: ConfidenceStruct) async throws -> ResolvesResult {
+                self.resolveStats += 1
+                return .init(resolvedValues: resolvedValues, resolveToken: "token")
+            }
+        }
+
+        let client = FakeClient()
+        client.resolvedValues = [
+            ResolvedValue(
+                variant: "control",
+                value: .init(structure: ["blob": .init(structure: ["size": .init(integer: 3), "name": .init(string: "testInner")]), "string": .init(string: "test")]),
+                flag: "flag",
+                resolveReason: .match,
+                shouldApply: false)
+        ]
+
+        struct Blob: Codable {
+            let size: Int
+            let name: String
+        }
+
+        struct Flag: Codable {
+            let string: String
+            let blob: Blob
+        }
+
+        let confidence = Confidence.Builder(clientSecret: "test")
+            .withContext(initialContext: ["targeting_key": .init(string: "user2")])
+            .withFlagResolverClient(flagResolver: client)
+            .withFlagApplier(flagApplier: flagApplier)
+            .build()
+
+        try await confidence.fetchAndActivate()
+        let defaultValue = Flag(string: "", blob: Blob(size: 0, name: ""))
+        let evaluation = confidence.getValue(
+            key: "flag",
+            defaultValue: defaultValue)
+
+        let expected = Flag(string: "test", blob: Blob(size: 3, name: "testInner"))
+        XCTAssertEqual(evaluation.string, expected.string)
+        XCTAssertEqual(evaluation.blob.size, expected.blob.size)
+        XCTAssertEqual(evaluation.blob.name, expected.blob.name)
+    }
 
     func testResolveAndApplyIntegerFlagNoSegmentMatch() async throws {
         class FakeClient: ConfidenceResolveClient {
@@ -694,7 +780,7 @@ class ConfidenceTest: XCTestCase {
         try await confidence.fetchAndActivate()
         let evaluation = confidence.getEvaluation(
             key: "flag.size",
-            defaultValue: [:])
+            defaultValue: ConfidenceStruct())
 
         XCTAssertEqual(client.resolveStats, 1)
         XCTAssertEqual(evaluation.value as? ConfidenceStruct, ["boolean": .init(boolean: true)])

--- a/Tests/ConfidenceTests/ConfidenceTest.swift
+++ b/Tests/ConfidenceTests/ConfidenceTest.swift
@@ -250,6 +250,7 @@ class ConfidenceTest: XCTestCase {
             }
         }
 
+        // swiftlint:disable:next line_length
         let expected: ConfidenceValue = .init(structure: ["blob": .init(structure: ["size": .init(integer: 3), "name": .init(string: "testInner")]), "string": .init(string: "test")])
         let client = FakeClient()
         client.resolvedValues = [
@@ -293,6 +294,7 @@ class ConfidenceTest: XCTestCase {
         client.resolvedValues = [
             ResolvedValue(
                 variant: "control",
+                // swiftlint:disable:next line_length
                 value: .init(structure: ["blob": .init(structure: ["size": .init(integer: 3), "name": .init(string: "testInner")]), "string": .init(string: "test")]),
                 flag: "flag",
                 resolveReason: .match,

--- a/Tests/ConfidenceTests/ConfidenceValueTests.swift
+++ b/Tests/ConfidenceTests/ConfidenceValueTests.swift
@@ -145,7 +145,8 @@ final class ConfidenceConfidenceValueTests: XCTestCase {
             ])
         ])
         let data = try value.asJSONData()
-        let dataAsString = try XCTUnwrap(String(data: data!, encoding: .utf8))
+        let dataAsString = try XCTUnwrap(String(data: data, encoding: .utf8))
+        // swiftlint:disable:next line_length
         XCTAssertEqual(dataAsString, "{\"field1\":3,\"field2\":\"test\",\"field3\":{\"field4\":4,\"field5\":\"test2\"}}")
     }
 }

--- a/Tests/ConfidenceTests/ConfidenceValueTests.swift
+++ b/Tests/ConfidenceTests/ConfidenceValueTests.swift
@@ -134,4 +134,18 @@ final class ConfidenceConfidenceValueTests: XCTestCase {
 
         XCTAssertEqual(value, decodedValue)
     }
+
+    func testAsJSONData() throws {
+        let value = ConfidenceValue(structure: [
+            "field1": ConfidenceValue(integer: 3),
+            "field2": ConfidenceValue(string: "test"),
+            "field3": ConfidenceValue(structure: [
+                "field4": ConfidenceValue(integer: 4),
+                "field5": ConfidenceValue(string: "test2")
+            ])
+        ])
+        let data = try value.asJSONData()
+        let dataAsString = try XCTUnwrap(String(data: data!, encoding: .utf8))
+        XCTAssertEqual(dataAsString, "{\"field1\":3,\"field2\":\"test\",\"field3\":{\"field4\":4,\"field5\":\"test2\"}}")
+    }
 }

--- a/Tests/ConfidenceTests/ConfidenceValueTests.swift
+++ b/Tests/ConfidenceTests/ConfidenceValueTests.swift
@@ -144,7 +144,7 @@ final class ConfidenceConfidenceValueTests: XCTestCase {
                 "field5": ConfidenceValue(string: "test2")
             ])
         ])
-        let data = try value.asJSONData()
+        let data = try XCTUnwrap(value.asJSONData())
         let dataAsString = try XCTUnwrap(String(data: data, encoding: .utf8))
         // swiftlint:disable:next line_length
         XCTAssertEqual(dataAsString, "{\"field1\":3,\"field2\":\"test\",\"field3\":{\"field4\":4,\"field5\":\"test2\"}}")

--- a/api/Confidence_public_api.json
+++ b/api/Confidence_public_api.json
@@ -20,11 +20,11 @@
       },
       {
         "name": "getEvaluation(key:defaultValue:)",
-        "declaration": "public func getEvaluation<T>(key: String, defaultValue: T) -> Evaluation<T>"
+        "declaration": "public func getEvaluation<T: Decodable>(key: String, defaultValue: T) -> Evaluation<T>"
       },
       {
         "name": "getValue(key:defaultValue:)",
-        "declaration": "public func getValue<T>(key: String, defaultValue: T) -> T"
+        "declaration": "public func getValue<T: Decodable>(key: String, defaultValue: T) -> T"
       },
       {
         "name": "getContext()",


### PR DESCRIPTION
# This PR introduces 
a significant enhancement to the Confidence SDK for Swift by adding support for passing Decodable structs directly to flag evaluation. The main changes include:

## API Methods:
* Updated `getEvaluation<T: Decodable>(key: String, defaultValue: T)` method that allows passing a Codable struct as context
* Updated `getValue<T: Decodable>(key: String, defaultValue: T)` method for direct value retrieval with context

## Type Safety:
This provides better compile-time checking and IDE support compared to the dictionary-based approach

## Backward Compatibility:
All existing methods continue to work as before since ConfidenceValue's are Codeable.

## This enhancement makes the SDK more Swift-idiomatic by:
* Leveraging Swift's type system more effectively
* Providing better developer experience with compile-time type checking
* Making it easier to work with structured data in flag evaluations
* Reducing the need for manual conversion between structs and dictionaries

## The changes are particularly useful for developers who want to:
* Pass strongly-typed context data to flag evaluations
* Work with complex data structures in their flag evaluations
* Maintain type safety throughout their flag evaluation code

# Open questions
* How do we handle when there's a mis match between flag struct and the decodable struct?