### PR TITLE
fix: change how we log resolve tester hints

### DIFF
--- a/Sources/Confidence/DebugLogger.swift
+++ b/Sources/Confidence/DebugLogger.swift
@@ -33,7 +33,10 @@ class DebugLoggerImpl: DebugLogger {
             let jsonData = try JSONSerialization.data(withJSONObject: resolveHintData, options: [])
             if let jsonString = String(data: jsonData, encoding: .utf8) {
                 let base64 = Data(jsonString.utf8).base64EncodedString()
-                let message = "Check your flag evaluation for \(flagName) by copy pasting the payload to the Resolve tester '\(base64)'"
+                let message = """
+                    Check your flag evaluation for \(flagName)
+                    by copy pasting the payload to the Resolve tester '\(base64)'
+                """
                 log(messageLevel: .DEBUG, message: message)
             } else {
                 log(messageLevel: .DEBUG, message: "Could not convert JSON data to string")

--- a/Sources/Confidence/DebugLogger.swift
+++ b/Sources/Confidence/DebugLogger.swift
@@ -1,7 +1,7 @@
 import Foundation
 import OSLog
 
-internal protocol DebugLogger {
+protocol DebugLogger {
     func logEvent(action: String, event: ConfidenceEvent?)
     func logMessage(message: String, isWarning: Bool)
     func logFlags(action: String, flag: String)
@@ -16,31 +16,34 @@ private extension Logger {
     static let confidence = Logger(subsystem: subsystem ?? "", category: "confidence")
 }
 
-internal class DebugLoggerImpl: DebugLogger {
+class DebugLoggerImpl: DebugLogger {
     private let encoder = JSONEncoder()
-    private let clientKey: String
+    let clientKey: String
 
     func logResolveDebugURL(flagName: String, context: ConfidenceStruct) {
-        let ctxNetworkValue = TypeMapper.convert(structure: context)
-        if let ctxNetworkData = try? encoder.encode(ctxNetworkValue),
-        let ctxNetworkString = String(data: ctxNetworkData, encoding: .utf8) {
-            var url = URLComponents()
-            url.scheme = "https"
-            url.host = "app.confidence.spotify.com"
-            url.path = "/flags/resolver-test"
-            url.queryItems = [
-                URLQueryItem(name: "client-key", value: clientKey),
-                URLQueryItem(name: "flag", value: "flags/\(flagName)"),
-                URLQueryItem(name: "context", value: "\(ctxNetworkString)"),
+        let ctxNetworkValue: NetworkStruct = TypeMapper.convert(structure: context)
+        do {
+            let ctxNetworkData = try encoder.encode(ctxNetworkValue)
+
+            let resolveHintData = try [
+                "context": JSONSerialization.jsonObject(with: ctxNetworkData, options: []),
+                "flag": "flags/\(flagName)",
+                "clientKey": clientKey,
             ]
-            log(messageLevel: .DEBUG, message: """
-                See resolves for \(flagName) in Confidence:
-                \(url.url?.absoluteString ?? "N/A")
-            """)
+            let jsonData = try JSONSerialization.data(withJSONObject: resolveHintData, options: [])
+            if let jsonString = String(data: jsonData, encoding: .utf8) {
+                let base64 = Data(jsonString.utf8).base64EncodedString()
+                let message = "Check your flag evaluation for \(flagName) by copy pasting the payload to the Resolve tester '\(base64)'"
+                log(messageLevel: .DEBUG, message: message)
+            } else {
+                log(messageLevel: .DEBUG, message: "Could not convert JSON data to string")
+            }
+        } catch {
+            log(messageLevel: .DEBUG, message: "Failed to encode resolve hint data: \(error)")
         }
     }
 
-    private let loggerLevel: LoggerLevel
+    let loggerLevel: LoggerLevel
 
     init(loggerLevel: LoggerLevel, clientKey: String) {
         self.loggerLevel = loggerLevel
@@ -71,7 +74,7 @@ internal class DebugLoggerImpl: DebugLogger {
         log(messageLevel: .TRACE, message: "[\(action)] \(context)")
     }
 
-    private func log(messageLevel: LoggerLevel, message: String) {
+    func log(messageLevel: LoggerLevel, message: String) {
         if messageLevel >= loggerLevel {
             switch messageLevel {
             case .TRACE:

--- a/Tests/ConfidenceTests/DebugLoggerTests.swift
+++ b/Tests/ConfidenceTests/DebugLoggerTests.swift
@@ -1,0 +1,172 @@
+import Foundation
+import OSLog
+import XCTest
+
+@testable import Confidence
+
+/// A testable debug logger that captures log output
+class TestableDebugLogger: DebugLoggerImpl {
+    var capturedLogs: [(level: LoggerLevel, message: String)] = []
+
+    override func log(messageLevel: LoggerLevel, message: String) {
+        capturedLogs.append((level: messageLevel, message: message))
+        super.log(messageLevel: messageLevel, message: message)
+    }
+
+    func clearCapturedLogs() {
+        capturedLogs.removeAll()
+    }
+}
+
+class DebugLoggerTests: XCTestCase {
+    var debugLogger: TestableDebugLogger!
+
+    override func setUp() {
+        super.setUp()
+        debugLogger = TestableDebugLogger(loggerLevel: .DEBUG, clientKey: "my-client-key")
+        debugLogger.capturedLogs.removeAll()
+    }
+
+    override func tearDown() {
+        debugLogger = nil
+        super.tearDown()
+    }
+
+    func testLogResolveDebugURL() {
+        let context: ConfidenceStruct = [
+            "user_id": .init(string: "123"),
+            "email": .init(string: "test@test.com"),
+        ]
+
+        debugLogger.logResolveDebugURL(flagName: "my-flag", context: context)
+        XCTAssertFalse(debugLogger.capturedLogs.isEmpty, "No logs were captured")
+        let debugLog = debugLogger.capturedLogs.first { $0.level == .DEBUG && $0.message.contains("Check your flag evaluation for my-flag") }
+        XCTAssertNotNil(debugLog, "Expected debug log not found")
+        // Extract base64 string from log message
+        guard let base64String = debugLog?.message.split(separator: "'").dropFirst().first else {
+            XCTFail("Could not extract base64 string from log message")
+            return
+        }
+
+        // Decode base64 to JSON string
+        guard let decodedData = Data(base64Encoded: String(base64String)),
+              let decodedString = String(data: decodedData, encoding: .utf8),
+              let jsonData = decodedString.data(using: .utf8),
+              let decodedJson = try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any]
+        else {
+            XCTFail("Could not decode base64 string to JSON")
+            return
+        }
+
+        // Verify decoded JSON structure
+        XCTAssertEqual(decodedJson["clientKey"] as? String, "my-client-key")
+        XCTAssertEqual(decodedJson["flag"] as? String, "flags/my-flag")
+
+        guard let contextDict = decodedJson["context"] as? [String: String] else {
+            XCTFail("Context not found in decoded JSON")
+            return
+        }
+
+        XCTAssertEqual(contextDict["user_id"], "123")
+        XCTAssertEqual(contextDict["email"], "test@test.com")
+    }
+
+    func testLogResolveDebugURLWithEmptyContext() {
+        let context: ConfidenceStruct = [:]
+
+        debugLogger.logResolveDebugURL(flagName: "my-flag", context: context)
+        XCTAssertFalse(debugLogger.capturedLogs.isEmpty, "No logs were captured")
+        let debugLog = debugLogger.capturedLogs.first { $0.level == .DEBUG && $0.message.contains("Check your flag evaluation for my-flag") }
+        XCTAssertNotNil(debugLog, "Expected debug log not found")
+
+        guard let base64String = debugLog?.message.split(separator: "'").dropFirst().first else {
+            XCTFail("Could not extract base64 string from log message")
+            return
+        }
+
+        guard let decodedData = Data(base64Encoded: String(base64String)),
+              let decodedString = String(data: decodedData, encoding: .utf8),
+              let jsonData = decodedString.data(using: .utf8),
+              let decodedJson = try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any]
+        else {
+            XCTFail("Could not decode base64 string to JSON")
+            return
+        }
+
+        XCTAssertEqual(decodedJson["clientKey"] as? String, "my-client-key")
+        XCTAssertEqual(decodedJson["flag"] as? String, "flags/my-flag")
+
+        guard let contextDict = decodedJson["context"] as? [String: Any] else {
+            XCTFail("Context not found in decoded JSON")
+            return
+        }
+
+        XCTAssertTrue(contextDict.isEmpty, "Context should be empty")
+    }
+
+    func testLogResolveDebugURLWithComplexContext() {
+        let context: ConfidenceStruct = [
+            "user_id": .init(string: "123"),
+            "email": .init(string: "test@test.com"),
+            "age": .init(integer: 25),
+            "premium": .init(boolean: true),
+            "score": .init(double: 98.6),
+            "preferences": .init(structure: [
+                "theme": .init(string: "dark"),
+                "notifications": .init(boolean: true),
+                "favorites": .init(list: [
+                    .init(string: "item1"),
+                    .init(string: "item2"),
+                ]),
+            ]),
+        ]
+
+        debugLogger.logResolveDebugURL(flagName: "my-flag", context: context)
+        XCTAssertFalse(debugLogger.capturedLogs.isEmpty, "No logs were captured")
+        let debugLog = debugLogger.capturedLogs.first { $0.level == .DEBUG && $0.message.contains("Check your flag evaluation for my-flag") }
+        XCTAssertNotNil(debugLog, "Expected debug log not found")
+
+        guard let base64String = debugLog?.message.split(separator: "'").dropFirst().first else {
+            XCTFail("Could not extract base64 string from log message")
+            return
+        }
+
+        guard let decodedData = Data(base64Encoded: String(base64String)),
+              let decodedString = String(data: decodedData, encoding: .utf8),
+              let jsonData = decodedString.data(using: .utf8),
+              let decodedJson = try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any]
+        else {
+            XCTFail("Could not decode base64 string to JSON")
+            return
+        }
+
+        XCTAssertEqual(decodedJson["clientKey"] as? String, "my-client-key")
+        XCTAssertEqual(decodedJson["flag"] as? String, "flags/my-flag")
+
+        guard let contextDict = decodedJson["context"] as? [String: Any] else {
+            XCTFail("Context not found in decoded JSON")
+            return
+        }
+
+        XCTAssertEqual(contextDict["user_id"] as? String, "123")
+        XCTAssertEqual(contextDict["email"] as? String, "test@test.com")
+        XCTAssertEqual(contextDict["age"] as? Int, 25)
+        XCTAssertEqual(contextDict["premium"] as? Bool, true)
+        XCTAssertEqual(contextDict["score"] as? Double, 98.6)
+
+        guard let preferences = contextDict["preferences"] as? [String: Any] else {
+            XCTFail("Preferences not found in context")
+            return
+        }
+
+        XCTAssertEqual(preferences["theme"] as? String, "dark")
+        XCTAssertEqual(preferences["notifications"] as? Bool, true)
+
+        guard let favorites = preferences["favorites"] as? [String] else {
+            XCTFail("Favorites not found in preferences")
+            return
+        }
+
+        XCTAssertEqual(favorites, ["item1", "item2"])
+    }
+}

--- a/Tests/ConfidenceTests/DebugLoggerTests.swift
+++ b/Tests/ConfidenceTests/DebugLoggerTests.swift
@@ -19,7 +19,9 @@ class TestableDebugLogger: DebugLoggerImpl {
 }
 
 class DebugLoggerTests: XCTestCase {
+    // swiftlint:disable implicitly_unwrapped_optional
     var debugLogger: TestableDebugLogger!
+    // swiftlint:enable implicitly_unwrapped_optional
 
     override func setUp() {
         super.setUp()
@@ -40,7 +42,8 @@ class DebugLoggerTests: XCTestCase {
 
         debugLogger.logResolveDebugURL(flagName: "my-flag", context: context)
         XCTAssertFalse(debugLogger.capturedLogs.isEmpty, "No logs were captured")
-        let debugLog = debugLogger.capturedLogs.first { $0.level == .DEBUG && $0.message.contains("Check your flag evaluation for my-flag") }
+        let debugLog = debugLogger.capturedLogs
+            .first { $0.level == .DEBUG && $0.message.contains("Check your flag evaluation for my-flag") }
         XCTAssertNotNil(debugLog, "Expected debug log not found")
         // Extract base64 string from log message
         guard let base64String = debugLog?.message.split(separator: "'").dropFirst().first else {
@@ -50,9 +53,9 @@ class DebugLoggerTests: XCTestCase {
 
         // Decode base64 to JSON string
         guard let decodedData = Data(base64Encoded: String(base64String)),
-              let decodedString = String(data: decodedData, encoding: .utf8),
-              let jsonData = decodedString.data(using: .utf8),
-              let decodedJson = try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any]
+            let decodedString = String(data: decodedData, encoding: .utf8),
+            let jsonData = decodedString.data(using: .utf8),
+            let decodedJson = try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any]
         else {
             XCTFail("Could not decode base64 string to JSON")
             return
@@ -76,7 +79,8 @@ class DebugLoggerTests: XCTestCase {
 
         debugLogger.logResolveDebugURL(flagName: "my-flag", context: context)
         XCTAssertFalse(debugLogger.capturedLogs.isEmpty, "No logs were captured")
-        let debugLog = debugLogger.capturedLogs.first { $0.level == .DEBUG && $0.message.contains("Check your flag evaluation for my-flag") }
+        let debugLog = debugLogger.capturedLogs
+            .first { $0.level == .DEBUG && $0.message.contains("Check your flag evaluation for my-flag") }
         XCTAssertNotNil(debugLog, "Expected debug log not found")
 
         guard let base64String = debugLog?.message.split(separator: "'").dropFirst().first else {
@@ -85,9 +89,9 @@ class DebugLoggerTests: XCTestCase {
         }
 
         guard let decodedData = Data(base64Encoded: String(base64String)),
-              let decodedString = String(data: decodedData, encoding: .utf8),
-              let jsonData = decodedString.data(using: .utf8),
-              let decodedJson = try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any]
+            let decodedString = String(data: decodedData, encoding: .utf8),
+            let jsonData = decodedString.data(using: .utf8),
+            let decodedJson = try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any]
         else {
             XCTFail("Could not decode base64 string to JSON")
             return
@@ -123,7 +127,8 @@ class DebugLoggerTests: XCTestCase {
 
         debugLogger.logResolveDebugURL(flagName: "my-flag", context: context)
         XCTAssertFalse(debugLogger.capturedLogs.isEmpty, "No logs were captured")
-        let debugLog = debugLogger.capturedLogs.first { $0.level == .DEBUG && $0.message.contains("Check your flag evaluation for my-flag") }
+        let debugLog = debugLogger.capturedLogs
+            .first { $0.level == .DEBUG && $0.message.contains("Check your flag evaluation for my-flag") }
         XCTAssertNotNil(debugLog, "Expected debug log not found")
 
         guard let base64String = debugLog?.message.split(separator: "'").dropFirst().first else {
@@ -132,9 +137,9 @@ class DebugLoggerTests: XCTestCase {
         }
 
         guard let decodedData = Data(base64Encoded: String(base64String)),
-              let decodedString = String(data: decodedData, encoding: .utf8),
-              let jsonData = decodedString.data(using: .utf8),
-              let decodedJson = try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any]
+            let decodedString = String(data: decodedData, encoding: .utf8),
+            let jsonData = decodedString.data(using: .utf8),
+            let decodedJson = try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any]
         else {
             XCTFail("Could not decode base64 string to JSON")
             return


### PR DESCRIPTION
Resolver hint logs will now contain a base64 encoded string which can be pasted in the Confidence tools to support that we don't necessarily know the URL the user would want to use.


Had to change the "scope" of the DebugLogger in order to unit test this properly. We can restore it if we remove the tests.