### PR TITLE
ci: Run with secrets on external PRs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,7 @@
 name: CI
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - 'main'
   push:


### PR DESCRIPTION
## Why
External contributions would fail in CI if we don't allow for secrets. Error:
```
Run webfactory/ssh-agent@v0.7.0
Error: The ssh-private-key argument is empty. Maybe the secret has not been configured, or you are using a wrong secret name in your workflow file.
```
Example of affected PR: https://github.com/spotify/confidence-sdk-swift/pull/195

## According to AI:
<img width="600" alt="Screenshot 2025-06-09 at 12 20 07" src="https://github.com/user-attachments/assets/19ec64ad-e485-4e0e-8ef8-13b9fe360af5" />
