### PR TITLE
ci: Switch to http in Package

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -3,7 +3,7 @@
     "pins": [
       {
         "package": "OpenFeature",
-        "repositoryURL": "git@github.com:open-feature/swift-sdk.git",
+        "repositoryURL": "https://github.com/open-feature/swift-sdk.git",
         "state": {
           "branch": null,
           "revision": "e2be5852827d7d6b837b9a4e577bb52bea6322d7",

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
             targets: ["Confidence"])
     ],
     dependencies: [
-        .package(url: "git@github.com:open-feature/swift-sdk.git", .exact("0.3.0")),
+        .package(url: "https://github.com/open-feature/swift-sdk.git", .exact("0.3.0")),
     ],
     targets: [
         .target(


### PR DESCRIPTION
This was needed with https://github.com/spotify/confidence-sdk-swift/pull/198

(Looks like [this](https://github.com/spotify/confidence-sdk-swift/pull/197) runs CI from main, rather than the PR setup, hence pr 198 was green)