### PR TITLE
fix: improve taskmanager thread safety

### DIFF
--- a/Sources/Confidence/TaskManager.swift
+++ b/Sources/Confidence/TaskManager.swift
@@ -1,10 +1,17 @@
 import Foundation
 
 internal class TaskManager {
+    private let queue = DispatchQueue(label: "com.confidence.taskmanager")
+    private var _currentTask: Task<(), Never>?
+
     public var currentTask: Task<(), Never>? {
-        didSet {
-            if let oldTask = oldValue {
-                oldTask.cancel()
+        get { queue.sync { _currentTask } }
+        set {
+            queue.sync {
+                if let oldTask = _currentTask {
+                    oldTask.cancel()
+                }
+                _currentTask = newValue
             }
         }
     }

--- a/Tests/ConfidenceTests/ConfidenceTest.swift
+++ b/Tests/ConfidenceTests/ConfidenceTest.swift
@@ -915,6 +915,20 @@ class ConfidenceTest: XCTestCase {
             }
         }
     }
+
+    func testConcurrentPutContextAndWait() async {
+        let confidence = Confidence.Builder(clientSecret: "test").build()
+        await withTaskGroup(of: Void.self) { group in
+            for i in 0..<1000 {
+                group.addTask {
+                    await confidence.putContextAndWait(key: "key\(i)", value: ConfidenceValue(string: "value\(i)"))
+                }
+            }
+        }
+        await confidence.awaitReconciliation()
+        // If we reach here without a crash, the test passes
+        XCTAssertTrue(true)
+    }
 }
 
 final class DispatchQueueFake: DispatchQueueType {

--- a/Tests/ConfidenceTests/TaskManagerTests.swift
+++ b/Tests/ConfidenceTests/TaskManagerTests.swift
@@ -68,6 +68,21 @@ class TaskManagerTests: XCTestCase {
         XCTAssertEqual(finalSignal2, true)
     }
 
+    func testConcurrentSetCurrentTask() async {
+        let taskManager = TaskManager()
+        await withTaskGroup(of: Void.self) { group in
+            for _ in 0..<10000 {
+                group.addTask {
+                    let task = Task { await Task.yield() }
+                    taskManager.currentTask = task
+                }
+            }
+        }
+        await taskManager.awaitReconciliation()
+        // If we reach here without a crash, the test passes
+        XCTAssertTrue(true)
+    }
+
     private actor SignalManager {
         private var _signal1 = false
         private var _signal2 = false


### PR DESCRIPTION
There were reported crashes pointing to a threading issue in the `TaskManager`:
```
Crashed: com.apple.root.user-initiated-qos.cooperative
EXC_BREAKPOINT 0x000000019dabe744
0
libswift_Concurrency.dylib
swift::AsyncTask::~AsyncTask() + 404
1
libswift_Concurrency.dylib
destroyTask(swift::HeapObject*) + 20
2
libswiftCore.dylib
_swift_release_dealloc + 56
3
libswiftCore.dylib
bool swift::RefCounts<swift::RefCountBitsT<(swift::RefCountInlinedness)1>>::doDecrementSlow<(swift::PerformDeinit)1>(swift::RefCountBitsT<(swift::RefCountInlinedness)1>, unsigned int) + 152
4
Confidence
TaskManager.swift - Line 7
TaskManager.currentTask.setter + 7
5
Confidence
Confidence.swift - Line 158
Confidence.putContextAndWait(key:value:) + 158
6
libswift_Concurrency.dylib
swift::runJobInEstablishedExecutorContext(swift::Job*) + 292
```

We believe wrapping the access of `currentTask` in a queue should provide enough protection against simultaneous access.