### PR TITLE
feat!: fix: Restore ConfidenceStruct evals, align Dictionary evals

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,9 +148,10 @@ let messageValue = messageFlag.value
 // message and messageValue are the same
 ```
 
-It's also possible to pass a Dictionary as evaluation type, for flags with a complex schema. The dictionary can
-only contain keys that map to properties in the complex flag, both in terms of property name and property type, otherwise
-the default value is returned with a `typeMismatch` error.
+It's also possible to use Swift Dictionary (`[String: Any]`) type or ConfidenceStruct type as default value, to evaluate flags
+with a complex schema in a single API call. Importantly, there are no guarantees that the value returned by a successful
+evaluation will resemble the structure of the default value, and extra care is advised when parsing the final value
+to avoid runtime errors.
 
 ### Tracking events
 The Confidence instance offers APIs to track events, which are uploaded to the Confidence backend:

--- a/Sources/Confidence/FlagEvaluation.swift
+++ b/Sources/Confidence/FlagEvaluation.swift
@@ -258,7 +258,11 @@ extension FlagResolution {
             }
             result = value.asNative()
         case .structure:
-            result = try handleStructureValue(value: value, defaultValue: defaultValue)
+            if (defaultValue as? ConfidenceStruct) != nil {
+                result = value.asStructure() as? T
+            } else {
+                result = try handleStructureValue(value: value, defaultValue: defaultValue)
+            }
         case .null:
             return nil
         }

--- a/Sources/Confidence/FlagEvaluation.swift
+++ b/Sources/Confidence/FlagEvaluation.swift
@@ -258,7 +258,13 @@ extension FlagResolution {
             }
             result = value.asNative()
         case .structure:
-            if (defaultValue as? ConfidenceStruct) != nil {
+            if let defaultStruct = defaultValue as? ConfidenceStruct,
+                let resolvedStruct = value.asStructure() {
+                result = StructMerger.mergeStructWithDefault(
+                    resolved: resolvedStruct,
+                    defaultStruct: defaultStruct
+                ) as? T
+            } else if (defaultValue as? ConfidenceStruct) != nil {
                 result = value.asStructure() as? T
             } else {
                 result = try handleStructureValue(value: value, defaultValue: defaultValue)

--- a/Sources/Confidence/FlagEvaluation.swift
+++ b/Sources/Confidence/FlagEvaluation.swift
@@ -264,10 +264,14 @@ extension FlagResolution {
                     resolved: resolvedStruct,
                     defaultStruct: defaultStruct
                 ) as? T
-            } else if (defaultValue as? ConfidenceStruct) != nil {
-                result = value.asStructure() as? T
+            } else if let defaultDict = defaultValue as? [String: Any],
+                let resolvedStruct = value.asStructure() {
+                result = StructMerger.mergeDictionaryWithDefault(
+                    resolved: resolvedStruct,
+                    defaultDict: defaultDict)
             } else {
-                result = try handleStructureValue(value: value, defaultValue: defaultValue)
+                throw ConfidenceError.typeMismatch(
+                    message: "Expected ConfidenceStruct or Dictionary as default value")
             }
         case .null:
             return nil
@@ -277,112 +281,6 @@ extension FlagResolution {
             return typedResult
         } else {
             throw ConfidenceError.typeMismatch(message: "Value \(value) cannot be cast to \(T.self)")
-        }
-    }
-
-    private func handleStructureValue<T>(value: ConfidenceValue, defaultValue: T) throws -> [String: Any] {
-        guard let defaultDict = defaultValue as? [String: Any] else {
-            throw ConfidenceError
-                .typeMismatch(
-                    message: "Expected a Dictionary as default value, but got a different type"
-                )
-        }
-        guard let structure = value.asStructure() else {
-            throw ConfidenceError
-                .typeMismatch(
-                    message: "Unexpected error with internal ConfidenceStruct conversion"
-                )
-        }
-        try validateDictionaryStructureCompatibility(
-            structure: structure,
-            defaultDict: defaultDict
-        )
-        // Filter only the entries in the original default value
-        var filteredNative: [String: Any] = [:]
-        for requiredKey in defaultDict.keys {
-            if let confidenceValue = structure[requiredKey] {
-                // If the resolved value is null, use the default value instead
-                if confidenceValue.isNull() {
-                    filteredNative[requiredKey] = defaultDict[requiredKey]
-                } else {
-                    filteredNative[requiredKey] = confidenceValue.asNative()
-                }
-            }
-        }
-        return filteredNative
-    }
-
-    private func validateDictionaryStructureCompatibility(
-        structure: ConfidenceStruct,
-        defaultDict: [String: Any]
-    ) throws {
-        for defaultValueKey in defaultDict.keys {
-            guard let confidenceValue = structure[defaultValueKey] else {
-                throw ConfidenceError.typeMismatch(
-                    message: "Default value key '\(defaultValueKey)' not found in flag"
-                )
-            }
-
-            // If the resolved value is null, it's compatible with any type (we'll use default value)
-            if confidenceValue.isNull() {
-                continue
-            }
-
-            let defaultValueValue: Any? = defaultDict[defaultValueKey]
-            if !isValueCompatibleWithDefaultValue(
-                confidenceType: confidenceValue.type(),
-                defaultValue: defaultValueValue
-            ) {
-                let message = "Default value key '\(defaultValueKey)' has incompatible type. " +
-                    "Expected from flag is '\(getIntrinsicType(of: defaultValueValue))', " +
-                    "got '\(confidenceValue.type())'"
-                throw ConfidenceError.typeMismatch(message: message)
-            }
-            if confidenceValue.type() == .list,
-                let defaultList = defaultValueValue as? [Any],
-                let resolvedList = confidenceValue.asList() {
-                try checkListElementTypeCompatibility(
-                    defaultList: defaultList,
-                    resolvedList: resolvedList,
-                    errorContext: defaultValueKey
-                )
-            }
-        }
-    }
-
-    private func getIntrinsicType(of value: Any?) -> String {
-        if let unwrapped = value {
-            return "\(type(of: unwrapped))"
-        } else {
-            return "nil"
-        }
-    }
-
-    private func isValueCompatibleWithDefaultValue(
-        confidenceType: ConfidenceValueType,
-        defaultValue: Any?
-    ) -> Bool {
-        switch defaultValue {
-        case is String:
-            return confidenceType == .string
-        case is Int, is Int32, is Int64:
-            return confidenceType == .integer
-        case is Double, is Float:
-            return confidenceType == .double
-        case is Bool:
-            return confidenceType == .boolean
-        case is Date:
-            return confidenceType == .timestamp
-        case is DateComponents:
-            return confidenceType == .date
-        case is Array<Any>:
-            return confidenceType == .list
-        case is [String: Any]:
-            return confidenceType == .structure
-        case .none: // TODO This requires extra care
-            return confidenceType == .null
-        default:
-            return false
         }
     }
 

--- a/Sources/Confidence/StructMerger.swift
+++ b/Sources/Confidence/StructMerger.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+internal enum StructMerger {
+    static func mergeStructWithDefault(
+        resolved: ConfidenceStruct,
+        defaultStruct: ConfidenceStruct
+    ) -> ConfidenceStruct {
+        var merged = resolved
+
+        // Only replace null values with defaults
+        for (key, resolvedValue) in resolved {
+            if resolvedValue.isNull(), let defaultValue = defaultStruct[key] {
+                merged[key] = defaultValue
+            } else if let resolvedNested = resolvedValue.asStructure(),
+                let defaultNested = defaultStruct[key]?.asStructure() {
+                // Recursively merge nested structs
+                merged[key] = ConfidenceValue(
+                    structure: mergeStructWithDefault(
+                        resolved: resolvedNested,
+                        defaultStruct: defaultNested))
+            }
+        }
+
+        return merged
+    }
+}

--- a/Tests/ConfidenceProviderTests/ConfidenceProviderTest.swift
+++ b/Tests/ConfidenceProviderTests/ConfidenceProviderTest.swift
@@ -9,6 +9,11 @@ import XCTest
 
 // swiftlint:disable:next type_body_length
 class ConfidenceProviderTest: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        OpenFeatureAPI.shared.clearProvider()
+    }
+
     // MARK: - Helper Functions
 
     private func createFakeClient(
@@ -72,12 +77,11 @@ class ConfidenceProviderTest: XCTestCase {
     private func setupProviderAndWaitForReady(
         confidence: Confidence,
         initializationStrategy: InitializationStrategy = .fetchAndActivate,
-        timeout: TimeInterval = 1.0
+        timeout: TimeInterval = 5.0
     ) async -> AnyCancellable {
         let readyExpectation = XCTestExpectation(description: "Ready")
 
         let provider = ConfidenceFeatureProvider(confidence: confidence, initializationStrategy: initializationStrategy)
-        OpenFeatureAPI.shared.setProvider(provider: provider)
 
         let cancellable = OpenFeatureAPI.shared.observe().sink { event in
             if event == .ready {
@@ -87,6 +91,7 @@ class ConfidenceProviderTest: XCTestCase {
             }
         }
 
+        OpenFeatureAPI.shared.setProvider(provider: provider)
         await fulfillment(of: [readyExpectation], timeout: timeout)
         return cancellable
     }
@@ -99,8 +104,6 @@ class ConfidenceProviderTest: XCTestCase {
         let errorExpectation = XCTestExpectation(description: "Error")
 
         let provider = ConfidenceFeatureProvider(confidence: confidence, initializationStrategy: initializationStrategy)
-        OpenFeatureAPI.shared.setProvider(provider: provider)
-
         let cancellable = OpenFeatureAPI.shared.observe().sink { event in
             if let event = event {
                 if case .error = event {
@@ -109,6 +112,7 @@ class ConfidenceProviderTest: XCTestCase {
             }
         }
 
+        OpenFeatureAPI.shared.setProvider(provider: provider)
         await fulfillment(of: [errorExpectation], timeout: timeout)
         return cancellable
     }

--- a/Tests/ConfidenceTests/ConfidenceTest.swift
+++ b/Tests/ConfidenceTests/ConfidenceTest.swift
@@ -1240,7 +1240,6 @@ class ConfidenceTest: XCTestCase {
         XCTAssertNil(evaluation.errorCode)
     }
 
-    // swiftlint:disable:next function_body_length
     func testStructMergerOnlyReplacesNulls() async throws {
         class FakeClient: ConfidenceResolveClient {
             func resolve(ctx: ConfidenceStruct) async throws -> ResolvesResult {
@@ -1301,7 +1300,6 @@ class ConfidenceTest: XCTestCase {
         XCTAssertNil(evaluation.errorCode)
     }
 
-    // swiftlint:disable:next function_body_length
     func testStructMergerNestedNulls() async throws {
         class FakeClient: ConfidenceResolveClient {
             func resolve(ctx: ConfidenceStruct) async throws -> ResolvesResult {


### PR DESCRIPTION
## Changelog
- #193 accidentally removed the capability of using `ConfidenceStruct` as default value for complex evaluations. This PR restores that capability.
- It also improves the logic for `null` entries in the remote variant: the default value for those entries is used, rather than null. This also aligns with the new behavior from the Dictionary-based evaluations. **This is a backwards incompatible change, despite probably minor**
- The Dictionary / OpenFeature complex evaluations are also aligned with the ConfidenceStruct merging logic