### PR TITLE
fix: Race condition and possible data inconsistencies

### DIFF
--- a/Sources/ConfidenceProvider/ConfidenceFeatureProvider.swift
+++ b/Sources/ConfidenceProvider/ConfidenceFeatureProvider.swift
@@ -64,10 +64,11 @@ public class ConfidenceFeatureProvider: FeatureProvider {
         oldContext: OpenFeature.EvaluationContext?,
         newContext: OpenFeature.EvaluationContext
     ) async {
+        let newContextMap = newContext.asMap()
+        let newKeys = Set(Array(newContextMap.keys))
         let removedKeys: [String] = oldContext.map { oldCtx in
-        let oldKeys = Array(oldCtx.asMap().keys)
-        let newKeys = Set(newContext.asMap().keys)
-        return oldKeys.filter { !newKeys.contains($0) }
+            let oldKeys = Array(oldCtx.asMap().keys)
+            return Array(Set(oldKeys).subtracting(newKeys))
         } ?? []
         await confidence.putContextAndWait(
             context: ConfidenceTypeMapper.from(ctx: newContext),

--- a/Sources/ConfidenceProvider/ConfidenceFeatureProvider.swift
+++ b/Sources/ConfidenceProvider/ConfidenceFeatureProvider.swift
@@ -66,12 +66,15 @@ public class ConfidenceFeatureProvider: FeatureProvider {
     ) async {
         let newContextMap = newContext.asMap()
         let newKeys = Set(Array(newContextMap.keys))
+        let targetingKey = newContext.getTargetingKey()
+
         let removedKeys: [String] = oldContext.map { oldCtx in
             let oldKeys = Array(oldCtx.asMap().keys)
             return Array(Set(oldKeys).subtracting(newKeys))
         } ?? []
+
         await confidence.putContextAndWait(
-            context: ConfidenceTypeMapper.from(ctx: newContext),
+            context: ConfidenceTypeMapper.from(contextMap: newContextMap, targetingKey: targetingKey),
             removedKeys: removedKeys)
     }
 

--- a/Sources/ConfidenceProvider/ConfidenceTypeMapper.swift
+++ b/Sources/ConfidenceProvider/ConfidenceTypeMapper.swift
@@ -11,10 +11,16 @@ public enum ConfidenceTypeMapper {
         guard let openFeatureContext = ctx else {
             return [:]
         }
-        var ofCtxMap = openFeatureContext.asMap()
-        // Precendence given to the `attributes` rather then the bespoke `targeting_key`
-        if !openFeatureContext.getTargetingKey().isEmpty && !ofCtxMap.keys.contains("targeting_key") {
-            ofCtxMap["targeting_key"] = .string(openFeatureContext.getTargetingKey())
+        let contextMap = openFeatureContext.asMap()
+        let targetingKey = openFeatureContext.getTargetingKey()
+        return from(contextMap: contextMap, targetingKey: targetingKey)
+    }
+
+    static func from(contextMap: [String: Value], targetingKey: String?) -> ConfidenceStruct {
+        var ofCtxMap = contextMap
+        // Precedence given to the `attributes` rather than the bespoke `targeting_key`
+        if let targetingKey = targetingKey, !targetingKey.isEmpty && !ofCtxMap.keys.contains("targeting_key") {
+            ofCtxMap["targeting_key"] = .string(targetingKey)
         }
         return ofCtxMap.compactMapValues(convertValue)
     }


### PR DESCRIPTION
The original crash was due to this line

```
let newKeys = Set(newContext.asMap().keys)  // CRASH: Dictionary.Keys is not thread-safe
```

By wrapping the keys into an Array, we create a thread-safe snapshot of the keys that can be safely used to instantiate the Set.

More changes in the PR are introduced to try reduce the risk of data inconsistency (not crash-risk race conditions), by creating the `newContextMap` map once and passing that down the chain.