### PR TITLE
fix: ShouldApply backwards compatibility

### DIFF
--- a/Sources/Confidence/ConfidenceClient.swift
+++ b/Sources/Confidence/ConfidenceClient.swift
@@ -16,6 +16,30 @@ struct ResolvedValue: Codable, Equatable {
     var flag: String
     var resolveReason: ResolveReason
     var shouldApply: Bool
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        variant = try container.decodeIfPresent(String.self, forKey: .variant)
+        value = try container.decodeIfPresent(ConfidenceValue.self, forKey: .value)
+        flag = try container.decode(String.self, forKey: .flag)
+        resolveReason = try container.decode(ResolveReason.self, forKey: .resolveReason)
+
+        // Default shouldApply to true for backward compatibility when field is missing
+        shouldApply = try container.decodeIfPresent(Bool.self, forKey: .shouldApply) ?? true
+    }
+
+    init(variant: String? = nil, value: ConfidenceValue? = nil, flag: String, resolveReason: ResolveReason, shouldApply: Bool = true) {
+        self.variant = variant
+        self.value = value
+        self.flag = flag
+        self.resolveReason = resolveReason
+        self.shouldApply = shouldApply
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case variant, value, flag, resolveReason, shouldApply
+    }
 }
 
 public struct ResolvesResult: Codable, Equatable {


### PR DESCRIPTION
We observed crashes with decoding error due to "no associate value for key shouldApply". We think the decoder is trying to read values stored prior to when the `shouldApply` key has been introduced.

The default `true` in these remote cases is acceptable, as over-reporting exposure is not detrimental to the validity of the data. 