### PR TITLE
ci: use dynamic simulator discovery for tests

### DIFF
--- a/.github/scripts/find-simulator.py
+++ b/.github/scripts/find-simulator.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Find an available simulator for a given platform."""
+
+import json
+import sys
+
+
+def find_simulator(platform: str) -> str | None:
+    """Find the first available simulator for the given platform.
+
+    Args:
+        platform: The platform name (iOS, watchOS, tvOS)
+
+    Returns:
+        The UDID of an available simulator, or None if not found.
+    """
+    data = json.load(sys.stdin)
+    devices = data["devices"]
+    runtime_prefix = f"com.apple.CoreSimulator.SimRuntime.{platform}"
+
+    for runtime, devs in devices.items():
+        if runtime.startswith(runtime_prefix):
+            for device in devs:
+                if device.get("isAvailable", False):
+                    return device["udid"]
+    return None
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print(f"Usage: {sys.argv[0]} <platform>", file=sys.stderr)
+        print("Example: xcrun simctl list devices available -j | ./find-simulator.py iOS", file=sys.stderr)
+        return 1
+
+    platform = sys.argv[1]
+    udid = find_simulator(platform)
+
+    if udid:
+        print(udid)
+        return 0
+    else:
+        print(f"No available simulator found for platform: {platform}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ConfidenceDemoApp/scripts/build.sh
+++ b/ConfidenceDemoApp/scripts/build.sh
@@ -4,9 +4,15 @@ set -e
 
 script_dir=$(dirname $0)
 root_dir="$script_dir/../"
+repo_root="$script_dir/../../"
+
+SIMULATOR=$(xcrun simctl list devices available -j | \
+    python3 "$repo_root/.github/scripts/find-simulator.py" iOS)
+
+echo "Using simulator: $SIMULATOR"
 
 (cd $root_dir &&
     xcodebuild \
         -quiet \
         -scheme ConfidenceDemoApp \
-        -destination 'generic/platform=iOS Simulator' )
+        -destination "id=$SIMULATOR" )

--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -10,10 +10,15 @@ if [[ -z "${test_runner_client_token// }" ]]; then
     test_runner_client_token=$(security find-generic-password -w -s 'swift-provider-e2e' -a 'confidence-test')
 fi
 
+SIMULATOR=$(xcrun simctl list devices available -j | \
+    python3 "$root_dir/.github/scripts/find-simulator.py" iOS)
+
+echo "Using simulator: $SIMULATOR"
+
 (cd $root_dir && \
     TEST_RUNNER_CLIENT_TOKEN=$test_runner_client_token TEST_RUNNER_TEST_FLAG_NAME=$2 xcodebuild \
         -quiet \
         -scheme Confidence-Package \
-        -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=18.5' \
+        -destination "id=$SIMULATOR" \
         -only-testing:ConfidenceTests/ConfidenceIntegrationTests \
-        test) 
+        test)

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -5,9 +5,14 @@ set -e
 script_dir=$(dirname $0)
 root_dir="$script_dir/../"
 
+SIMULATOR=$(xcrun simctl list devices available -j | \
+    python3 "$root_dir/.github/scripts/find-simulator.py" iOS)
+
+echo "Using simulator: $SIMULATOR"
+
 (cd $root_dir && \
     xcodebuild \
         -scheme Confidence-Package \
-        -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=18.5' \
+        -destination "id=$SIMULATOR" \
         -skip-testing:ConfidenceTests/ConfidenceIntegrationTests \
         test)


### PR DESCRIPTION
## Summary
- Add Python script to dynamically find available iOS simulators
- Update test scripts to use simulator ID instead of hardcoded device names/OS versions
- Prevents CI failures when GitHub Actions updates macOS images with different simulators

## Test plan
- [x] Verify CI tests pass on this PR
- [x] Confirm simulator is discovered correctly in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)