### PR TITLE
ci: fix flaky tests

### DIFF
--- a/Sources/Confidence/Apply/FlagApplierWithRetries.swift
+++ b/Sources/Confidence/Apply/FlagApplierWithRetries.swift
@@ -31,7 +31,7 @@ final class FlagApplierWithRetries: FlagApplier {
         self.cacheDataInteractor = cacheDataInteractor ?? CacheDataInteractor(cacheData: storedData ?? .empty())
 
         if triggerBatch {
-            Task(priority: .utility) {
+            Task {
                 await self.triggerBatch()
             }
         }

--- a/Tests/ConfidenceTests/EventSenderEngineTest.swift
+++ b/Tests/ConfidenceTests/EventSenderEngineTest.swift
@@ -189,7 +189,7 @@ final class EventSenderEngineTest: XCTestCase {
         let cancellable = uploaderMock.subject.sink { _ in
             uploadExpectation.fulfill()
         }
-        wait(for: [uploadExpectation], timeout: 1)
+        wait(for: [uploadExpectation], timeout: 5)
         let uploadRequest = uploaderMock.calledRequest
         XCTAssertEqual(uploadRequest?.count, 4)
 


### PR DESCRIPTION
## Summary
- Increase timeout in `testManualFlushWorks` from 1s to 5s
- Remove `.utility` priority from `FlagApplierWithRetries` Task to prevent CPU starvation on CI runners

These tests were timing out on CI due to:
1. Short timeout (1s) for async operations that involve multiple hops through Combine publishers
2. Low-priority Task that may not get scheduled quickly on resource-constrained CI runners

## Test plan
- [x] Verify CI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)