### PR TITLE
fix: empty struct default causing parseError in getObjectDetails

### DIFF
--- a/Sources/Confidence/FlagEvaluation.swift
+++ b/Sources/Confidence/FlagEvaluation.swift
@@ -258,7 +258,12 @@ extension FlagResolution {
             }
             result = value.asNative()
         case .structure:
-            if let defaultStruct = defaultValue as? ConfidenceStruct,
+            // Explicitly check T is ConfidenceStruct, not just any [String: Any].
+            // An empty [String: Any] can be cast to [String: ConfidenceValue] in Swift,
+            // which would incorrectly route through mergeStructWithDefault and return
+            // ConfidenceValue objects instead of native types.
+            if T.self == ConfidenceStruct.self,
+                let defaultStruct = defaultValue as? ConfidenceStruct,
                 let resolvedStruct = value.asStructure() {
                 result = StructMerger.mergeStructWithDefault(
                     resolved: resolvedStruct,

--- a/Tests/ConfidenceProviderTests/MixedTypesFlagIntegrationTest.swift
+++ b/Tests/ConfidenceProviderTests/MixedTypesFlagIntegrationTest.swift
@@ -1,0 +1,180 @@
+import Foundation
+import ConfidenceProvider
+import Combine
+import OpenFeature
+import XCTest
+
+@testable import Confidence
+
+@available(macOS 13.0, iOS 16.0, *)
+class MixedTypesFlagOpenFeatureIntegrationTest: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        OpenFeatureAPI.shared.clearProvider()
+    }
+
+    private func createMixedTypesClient() -> ConfidenceResolveClient {
+        class FakeClient: ConfidenceResolveClient {
+            func resolve(ctx: ConfidenceStruct) async throws -> ResolvesResult {
+                return .init(
+                    resolvedValues: [
+                        ResolvedValue(
+                            variant: "flags/my-feature/variants/treatment",
+                            value: .init(structure: [
+                                "color": .init(string: "green"),
+                                "size": .init(integer: 3),
+                                "enabled": .init(null: ()),
+                                "visible": .init(null: ())
+                            ]),
+                            flag: "my-feature",
+                            resolveReason: .match,
+                            shouldApply: true
+                        )
+                    ],
+                    resolveToken: "token-1"
+                )
+            }
+        }
+        return FakeClient()
+    }
+
+    private func setupProvider(confidence: Confidence) async -> AnyCancellable {
+        let readyExpectation = XCTestExpectation(description: "Ready")
+        let provider = ConfidenceFeatureProvider(
+            confidence: confidence,
+            initializationStrategy: .fetchAndActivate
+        )
+        let cancellable = OpenFeatureAPI.shared.observe().sink { event in
+            if event == .ready() {
+                readyExpectation.fulfill()
+            }
+        }
+        OpenFeatureAPI.shared.setProvider(provider: provider)
+        await fulfillment(of: [readyExpectation], timeout: 5.0)
+        return cancellable
+    }
+
+    func testResolvesFlagWithMixedTypesAndNulls() async throws {
+        let confidence = Confidence.Builder(clientSecret: "test")
+            .withContext(initialContext: ["targeting_key": .init(string: "test-user")])
+            .withFlagResolverClient(flagResolver: createMixedTypesClient())
+            .build()
+
+        let cancellable = await setupProvider(confidence: confidence)
+        let client = OpenFeatureAPI.shared.getClient()
+
+        // String field
+        let color = client.getStringDetails(key: "my-feature.color", defaultValue: "default")
+        XCTAssertEqual("green", color.value)
+        XCTAssertEqual("RESOLVE_REASON_MATCH", color.reason)
+        XCTAssertEqual("flags/my-feature/variants/treatment", color.variant)
+        XCTAssertNil(color.errorCode)
+
+        // Integer field
+        let size = client.getIntegerDetails(key: "my-feature.size", defaultValue: 0)
+        XCTAssertEqual(3, size.value)
+        XCTAssertEqual("RESOLVE_REASON_MATCH", size.reason)
+        XCTAssertNil(size.errorCode)
+
+        // Null boolean fields — default returned since value is null
+        let enabled = client.getBooleanDetails(key: "my-feature.enabled", defaultValue: false)
+        XCTAssertEqual(false, enabled.value)
+        XCTAssertEqual("RESOLVE_REASON_MATCH", enabled.reason)
+
+        let visible = client.getBooleanDetails(key: "my-feature.visible", defaultValue: false)
+        XCTAssertEqual(false, visible.value)
+
+        // Full flag as object with populated defaults
+        let defaultStructure = Value.structure([
+            "color": .string("default"),
+            "size": .integer(0),
+            "enabled": .boolean(false),
+            "visible": .boolean(false)
+        ])
+        let fullFlag = client.getObjectDetails(
+            key: "my-feature", defaultValue: defaultStructure)
+        XCTAssertEqual("RESOLVE_REASON_MATCH", fullFlag.reason)
+        XCTAssertNil(fullFlag.errorCode)
+        guard case let .structure(flagStruct) = fullFlag.value else {
+            XCTFail("Expected structure value")
+            return
+        }
+        XCTAssertEqual(flagStruct["color"], .string("green"))
+        XCTAssertEqual(flagStruct["size"], .integer(3))
+        // Null boolean fields — default returned since value is null
+        XCTAssertEqual(flagStruct["enabled"], .boolean(false))
+        XCTAssertEqual(flagStruct["visible"], .boolean(false))
+
+        cancellable.cancel()
+    }
+
+    func testGetObjectDetailsWithEmptyDefaultStruct() async throws {
+        let confidence = Confidence.Builder(clientSecret: "test")
+            .withContext(initialContext: ["targeting_key": .init(string: "test-user")])
+            .withFlagResolverClient(flagResolver: createMixedTypesClient())
+            .build()
+
+        let cancellable = await setupProvider(confidence: confidence)
+        let client = OpenFeatureAPI.shared.getClient()
+
+        // Full flag as object with empty default — should not cause parseError
+        let fullFlag = client.getObjectDetails(
+            key: "my-feature", defaultValue: Value.structure([:]))
+        XCTAssertEqual("RESOLVE_REASON_MATCH", fullFlag.reason)
+        XCTAssertNil(fullFlag.errorCode)
+        guard case let .structure(flagStruct) = fullFlag.value else {
+            XCTFail("Expected structure value")
+            return
+        }
+        XCTAssertEqual(flagStruct["color"], .string("green"))
+        XCTAssertEqual(flagStruct["size"], .integer(3))
+        XCTAssertEqual(flagStruct["enabled"], .null)
+        XCTAssertEqual(flagStruct["visible"], .null)
+
+        cancellable.cancel()
+    }
+
+    private func createNoAssignmentClient() -> ConfidenceResolveClient {
+        class FakeClient: ConfidenceResolveClient {
+            func resolve(ctx: ConfidenceStruct) async throws -> ResolvesResult {
+                return .init(
+                    resolvedValues: [
+                        ResolvedValue(
+                            flag: "my-feature",
+                            resolveReason: .noSegmentMatch,
+                            shouldApply: true
+                        )
+                    ],
+                    resolveToken: "token-1"
+                )
+            }
+        }
+        return FakeClient()
+    }
+
+    func testNoAssignmentReturnsDefaults() async throws {
+        let confidence = Confidence.Builder(clientSecret: "test")
+            .withContext(initialContext: ["targeting_key": .init(string: "test-user")])
+            .withFlagResolverClient(flagResolver: createNoAssignmentClient())
+            .build()
+
+        let cancellable = await setupProvider(confidence: confidence)
+        let client = OpenFeatureAPI.shared.getClient()
+
+        let color = client.getStringDetails(key: "my-feature.color", defaultValue: "default")
+        XCTAssertEqual("default", color.value)
+        XCTAssertEqual("RESOLVE_REASON_NO_SEGMENT_MATCH", color.reason)
+        XCTAssertNil(color.variant)
+        XCTAssertNil(color.errorCode)
+
+        let size = client.getIntegerDetails(key: "my-feature.size", defaultValue: 0)
+        XCTAssertEqual(0, size.value)
+        XCTAssertEqual("RESOLVE_REASON_NO_SEGMENT_MATCH", size.reason)
+
+        let enabled = client.getBooleanDetails(key: "my-feature.enabled", defaultValue: false)
+        XCTAssertEqual(false, enabled.value)
+        XCTAssertEqual("RESOLVE_REASON_NO_SEGMENT_MATCH", enabled.reason)
+
+        cancellable.cancel()
+    }
+}

--- a/Tests/ConfidenceTests/MixedTypesFlagIntegrationTest.swift
+++ b/Tests/ConfidenceTests/MixedTypesFlagIntegrationTest.swift
@@ -1,0 +1,122 @@
+import Foundation
+import XCTest
+
+@testable import Confidence
+
+@available(macOS 13.0, iOS 16.0, *)
+class MixedTypesFlagIntegrationTest: XCTestCase {
+    private var flagApplier = FlagApplierMock()
+
+    override func setUp() {
+        flagApplier = FlagApplierMock()
+        super.setUp()
+    }
+
+    func testResolvesFlagWithMixedTypesAndNulls() async throws {
+        class FakeClient: ConfidenceResolveClient {
+            func resolve(ctx: ConfidenceStruct) async throws -> ResolvesResult {
+                return .init(
+                    resolvedValues: [
+                        ResolvedValue(
+                            variant: "flags/my-feature/variants/treatment",
+                            value: .init(structure: [
+                                "color": .init(string: "green"),
+                                "size": .init(integer: 3),
+                                "enabled": .init(null: ()),
+                                "visible": .init(null: ())
+                            ]),
+                            flag: "my-feature",
+                            resolveReason: .match,
+                            shouldApply: true
+                        )
+                    ],
+                    resolveToken: "token-1"
+                )
+            }
+        }
+
+        let confidence = Confidence.Builder(clientSecret: "test")
+            .withContext(initialContext: ["targeting_key": .init(string: "test-user")])
+            .withFlagResolverClient(flagResolver: FakeClient())
+            .withFlagApplier(flagApplier: flagApplier)
+            .build()
+
+        try await confidence.fetchAndActivate()
+
+        // String field
+        let color = confidence.getEvaluation(key: "my-feature.color", defaultValue: "default")
+        XCTAssertEqual("green", color.value)
+        XCTAssertEqual(.match, color.reason)
+        XCTAssertEqual("flags/my-feature/variants/treatment", color.variant)
+        XCTAssertNil(color.errorCode)
+        XCTAssertNil(color.errorMessage)
+
+        // Integer field
+        let size = confidence.getEvaluation(key: "my-feature.size", defaultValue: 0)
+        XCTAssertEqual(3, size.value)
+        XCTAssertEqual(.match, size.reason)
+        XCTAssertNil(size.errorCode)
+
+        // Null boolean fields — value is null, so default is returned
+        let enabled = confidence.getEvaluation(key: "my-feature.enabled", defaultValue: false)
+        XCTAssertEqual(false, enabled.value)
+        XCTAssertEqual(.match, enabled.reason)
+        XCTAssertEqual("flags/my-feature/variants/treatment", enabled.variant)
+
+        let visible = confidence.getEvaluation(key: "my-feature.visible", defaultValue: false)
+        XCTAssertEqual(false, visible.value)
+
+        // Full flag as struct
+        let fullFlag = confidence.getEvaluation(
+            key: "my-feature",
+            defaultValue: ConfidenceStruct()
+        )
+        XCTAssertEqual(.match, fullFlag.reason)
+        XCTAssertNil(fullFlag.errorCode)
+        let flagStruct = fullFlag.value
+        XCTAssertEqual(flagStruct["color"], ConfidenceValue(string: "green"))
+        XCTAssertEqual(flagStruct["size"], ConfidenceValue(integer: 3))
+        XCTAssertEqual(flagStruct["enabled"], ConfidenceValue(null: ()))
+        XCTAssertEqual(flagStruct["visible"], ConfidenceValue(null: ()))
+    }
+
+    func testNoAssignmentReturnsDefaults() async throws {
+        class FakeClient: ConfidenceResolveClient {
+            func resolve(ctx: ConfidenceStruct) async throws -> ResolvesResult {
+                return .init(
+                    resolvedValues: [
+                        ResolvedValue(
+                            flag: "my-feature",
+                            resolveReason: .noSegmentMatch,
+                            shouldApply: true
+                        )
+                    ],
+                    resolveToken: "token-1"
+                )
+            }
+        }
+
+        let confidence = Confidence.Builder(clientSecret: "test")
+            .withContext(initialContext: ["targeting_key": .init(string: "test-user")])
+            .withFlagResolverClient(flagResolver: FakeClient())
+            .withFlagApplier(flagApplier: flagApplier)
+            .build()
+
+        try await confidence.fetchAndActivate()
+
+        let color = confidence.getEvaluation(key: "my-feature.color", defaultValue: "default")
+        XCTAssertEqual("default", color.value)
+        XCTAssertEqual(.noSegmentMatch, color.reason)
+        XCTAssertNil(color.variant)
+        XCTAssertNil(color.errorCode)
+        XCTAssertNil(color.errorMessage)
+
+        let size = confidence.getEvaluation(key: "my-feature.size", defaultValue: 0)
+        XCTAssertEqual(0, size.value)
+        XCTAssertEqual(.noSegmentMatch, size.reason)
+
+        let enabled = confidence.getEvaluation(key: "my-feature.enabled", defaultValue: false)
+        XCTAssertEqual(false, enabled.value)
+        XCTAssertEqual(.noSegmentMatch, enabled.reason)
+    }
+}

--- a/Tests/ConfidenceTests/MixedTypesFlagIntegrationTest.swift
+++ b/Tests/ConfidenceTests/MixedTypesFlagIntegrationTest.swift
@@ -80,6 +80,53 @@ class MixedTypesFlagIntegrationTest: XCTestCase {
         XCTAssertEqual(flagStruct["visible"], ConfidenceValue(null: ()))
     }
 
+    func testEmptyDictionaryDefaultDoesNotCauseParseError() async throws {
+        class FakeClient: ConfidenceResolveClient {
+            func resolve(ctx: ConfidenceStruct) async throws -> ResolvesResult {
+                return .init(
+                    resolvedValues: [
+                        ResolvedValue(
+                            variant: "flags/my-feature/variants/treatment",
+                            value: .init(structure: [
+                                "color": .init(string: "green"),
+                                "size": .init(integer: 3),
+                                "enabled": .init(null: ()),
+                                "visible": .init(null: ())
+                            ]),
+                            flag: "my-feature",
+                            resolveReason: .match,
+                            shouldApply: true
+                        )
+                    ],
+                    resolveToken: "token-1"
+                )
+            }
+        }
+
+        let confidence = Confidence.Builder(clientSecret: "test")
+            .withContext(initialContext: ["targeting_key": .init(string: "test-user")])
+            .withFlagResolverClient(flagResolver: FakeClient())
+            .withFlagApplier(flagApplier: flagApplier)
+            .build()
+
+        try await confidence.fetchAndActivate()
+
+        // Empty [String: Any] default should not cause parseError
+        let emptyDefault: [String: Any] = [:]
+        let fullFlag = confidence.getEvaluation(
+            key: "my-feature",
+            defaultValue: emptyDefault
+        )
+        XCTAssertEqual(.match, fullFlag.reason)
+        XCTAssertNil(fullFlag.errorCode)
+        XCTAssertNil(fullFlag.errorMessage)
+        XCTAssertEqual("flags/my-feature/variants/treatment", fullFlag.variant)
+
+        let value = fullFlag.value
+        XCTAssertEqual(value["color"] as? String, "green")
+        XCTAssertEqual(value["size"] as? Int, 3)
+    }
+
     func testNoAssignmentReturnsDefaults() async throws {
         class FakeClient: ConfidenceResolveClient {
             func resolve(ctx: ConfidenceStruct) async throws -> ResolvesResult {


### PR DESCRIPTION
## Summary
- Fix edge case where passing `Value.structure([:])` as default to OpenFeature `getObjectDetails` caused a `parseError`
- Root cause: Swift's covariant empty dictionary casting allows `[String: Any]` to match `[String: ConfidenceValue]`, routing through the wrong merge path
- Add integration tests for mixed-type flags (strings, integers, null booleans) and no-assignment scenarios via both Confidence and OpenFeature APIs

## Test plan
- [x] `testResolvesFlagWithMixedTypesAndNulls` — Confidence API
- [x] `testResolvesFlagWithMixedTypesAndNulls` — OpenFeature API
- [x] `testGetObjectDetailsWithEmptyDefaultStruct` — reproduces and verifies the fix
- [x] `testNoAssignmentReturnsDefaults` — both Confidence and OpenFeature APIs
- [x] Full test suite passes (only pre-existing integration test failures requiring CLIENT_TOKEN)

🤖 Generated with [Claude Code](https://claude.com/claude-code)