### PR TITLE
feat: Migrate apply flow to ClientWriteFlagLogs with telemetry counters

### DIFF
--- a/ConfidenceDemoApp/ConfidenceDemoApp.xcodeproj/project.pbxproj
+++ b/ConfidenceDemoApp/ConfidenceDemoApp.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		734EBDDC2D565CAC006D3435 /* Confidence in Frameworks */ = {isa = PBXBuildFile; productRef = 734EBDDB2D565CAC006D3435 /* Confidence */; };
+		734EBDDE2D565CB0006D3435 /* ConfidenceOpenFeature in Frameworks */ = {isa = PBXBuildFile; productRef = 734EBDDD2D565CB0006D3435 /* ConfidenceOpenFeature */; };
 		735EADF52CF9B64E007BC42C /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 735EADF42CF9B64E007BC42C /* LoginView.swift */; };
 		C770C99A2A739FBC00C2AC8C /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C770C9962A739FBC00C2AC8C /* Preview Assets.xcassets */; };
 		C770C99B2A739FBC00C2AC8C /* ConfidenceDemoApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = C770C9972A739FBC00C2AC8C /* ConfidenceDemoApp.swift */; };
@@ -57,6 +58,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				734EBDDC2D565CAC006D3435 /* Confidence in Frameworks */,
+				734EBDDE2D565CB0006D3435 /* ConfidenceOpenFeature in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -170,6 +172,7 @@
 			name = ConfidenceDemoApp;
 			packageProductDependencies = (
 				734EBDDB2D565CAC006D3435 /* Confidence */,
+				734EBDDD2D565CB0006D3435 /* ConfidenceOpenFeature */,
 			);
 			productName = ConfidenceDemoApp;
 			productReference = C770C9682A739FA000C2AC8C /* ConfidenceDemoApp.app */;
@@ -649,6 +652,10 @@
 		734EBDDB2D565CAC006D3435 /* Confidence */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = Confidence;
+		};
+		734EBDDD2D565CB0006D3435 /* ConfidenceOpenFeature */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = ConfidenceOpenFeature;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/ConfidenceDemoApp/ConfidenceDemoApp/ConfidenceDemoApp.swift
+++ b/ConfidenceDemoApp/ConfidenceDemoApp/ConfidenceDemoApp.swift
@@ -1,4 +1,6 @@
 import Confidence
+import ConfidenceProvider
+import OpenFeature
 import SwiftUI
 
 @main
@@ -15,7 +17,7 @@ struct ConfidenceDemoApp: App {
     init() {
         @AppStorage("appVersion") var appVersion = 0
         @AppStorage("loggedUser") var loggedUser: String?
-        appVersion += 1 // Simulate update of the app on every new run
+        appVersion += 1
         var context = ["app_version": ConfidenceValue.init(integer: appVersion)]
         if let user = loggedUser {
             context["user_id"] = ConfidenceValue.init(string: user)
@@ -26,26 +28,28 @@ struct ConfidenceDemoApp: App {
             withAppInfo: true,
             withOsInfo: true,
             withLocale: true
-        ).decorated(context: context);
+        ).decorated(context: context)
 
         confidence = Confidence
             .Builder(clientSecret: secret, loggerLevel: .TRACE)
             .withContext(initialContext: context)
             .build()
-        
+
+        let provider = ConfidenceFeatureProvider(confidence: confidence)
+        OpenFeatureAPI.shared.setProvider(provider: provider)
+
         do {
-            // NOTE: here we are activating all the flag values from storage, regardless of how `context` looks now
             try confidence.activate()
         } catch {
             flaggingState.state = .error(ExperimentationFlags.CustomError(message: error.localizedDescription))
         }
-        // flaggingState.color is set here at startup and remains immutable until a user logs out
-        let eval = confidence.getEvaluation(
-            key: "swift-demoapp.color",
-            defaultValue: "Gray")
-        flaggingState.color = ContentView.getColor(
-            color: eval.value)
-        flaggingState.reason = eval.reason
+
+        let client = OpenFeatureAPI.shared.getClient()
+        let eval = client.getStringDetails(key: "swift-demoapp.color", defaultValue: "Gray")
+        print("[Telemetry] OpenFeature evaluation: key=swift-demoapp.color value=\(eval.value) reason=\(eval.reason ?? "nil")")
+
+        flaggingState.color = ContentView.getColor(color: eval.value)
+        flaggingState.reason = ResolveReason(rawValue: eval.reason ?? "") ?? .unknown
 
         self.appVersion = appVersion
         self.loggedUser = loggedUser
@@ -68,11 +72,10 @@ struct ConfidenceDemoApp: App {
         Task {
             do {
                 flaggingState.state = .loading
-                try await Task.sleep(nanoseconds: 2 * 1_000_000_000) // simulating slow network
-                // The flags in storage are refreshed for the current `context`, and activated
-                // After this line, fresh (and potentially new) flags values can be accessed
+                try await Task.sleep(nanoseconds: 2 * 1_000_000_000)
                 try await confidence.fetchAndActivate()
                 flaggingState.state = .ready
+                print("[Telemetry] Flags fetched and activated")
             } catch {
                 flaggingState.state = .error(ExperimentationFlags.CustomError(message: error.localizedDescription))
             }
@@ -81,7 +84,7 @@ struct ConfidenceDemoApp: App {
 }
 
 class ExperimentationFlags: ObservableObject {
-    var color: Color = .red // This is set on applicaaton start, and reset on user logout
+    var color: Color = .red
     var reason: ResolveReason = .unknown
     @Published var state: State = .notReady
 

--- a/ConfidenceDemoApp/ConfidenceDemoApp/ContentView.swift
+++ b/ConfidenceDemoApp/ConfidenceDemoApp/ContentView.swift
@@ -1,5 +1,7 @@
 import SwiftUI
 import Confidence
+import ConfidenceProvider
+import OpenFeature
 import Combine
 
 struct ContentView: View {
@@ -13,9 +15,11 @@ struct ContentView: View {
     private var loggedOut = false
 
     private let confidence: Confidence
+    private let ofClient: OpenFeature.Client
 
     init(confidence: Confidence, color: Color? = nil) {
         self.confidence = confidence
+        self.ofClient = OpenFeatureAPI.shared.getClient()
     }
 
     var body: some View {
@@ -68,26 +72,24 @@ struct ContentView: View {
                     Text("Loading the text color...")
                         .font(.body)
                 } else {
-                    let eval = confidence.getEvaluation(key: "swift-demoapp.color", defaultValue: "Gray")
+                    let eval = ofClient.getStringDetails(key: "swift-demoapp.color", defaultValue: "Gray")
                     Text("This text only appears after a successful flag fetching")
                         .font(.body)
                         .foregroundStyle(ContentView.getColor(color: eval.value))
                     Spacer()
-                    Text("[\(eval.reason)]")
+                    Text("[\(eval.reason ?? "unknown")]")
                 }
             }.frame(maxWidth: .infinity, alignment: .leading)
             .padding()
             HStack {
-                let eval = confidence.getEvaluation(
-                    key: "swift-demoapp.color",
-                    defaultValue: "Gray")
+                let eval = ofClient.getStringDetails(key: "swift-demoapp.color", defaultValue: "Gray")
                 Text("[2]")
                 Text("This text color dynamically changes on each flags fetch")
                     .font(.body)
                     .foregroundStyle(ContentView.getColor(
                         color: eval.value))
                 Spacer()
-                Text("[\(eval.reason)]")
+                Text("[\(eval.reason ?? "unknown")]")
             }.frame(maxWidth: .infinity, alignment: .leading)
                 .padding()
 
@@ -121,11 +123,13 @@ struct AboutPage: View {
     @State
     private var textColor = Color.red
     @State
-    private var reason = ResolveReason.unknown
+    private var reason: String = "unknown"
     private let confidence: Confidence
+    private let ofClient: OpenFeature.Client
 
     init(confidence: Confidence) {
         self.confidence = confidence
+        self.ofClient = OpenFeatureAPI.shared.getClient()
     }
 
     var body: some View {
@@ -135,10 +139,10 @@ struct AboutPage: View {
                 .foregroundStyle(textColor)
                 .padding()
                 .onAppear {
-                    let eval = confidence.getEvaluation(key: "swift-demoapp.color", defaultValue: "Gray")
+                    let eval = ofClient.getStringDetails(key: "swift-demoapp.color", defaultValue: "Gray")
                     textColor = ContentView.getColor(
                         color: eval.value)
-                    reason = eval.reason
+                    reason = eval.reason ?? "unknown"
                 }
             Spacer()
             Text("[\(reason)]")

--- a/ConfidenceDemoApp/ConfidenceDemoApp/LoginView.swift
+++ b/ConfidenceDemoApp/ConfidenceDemoApp/LoginView.swift
@@ -1,5 +1,7 @@
 import SwiftUI
 import Confidence
+import ConfidenceProvider
+import OpenFeature
 
 struct LoginView: View {
     @EnvironmentObject
@@ -32,25 +34,25 @@ struct LoginView: View {
                                 ExperimentationFlags.CustomError(message: error.localizedDescription))
                         }
 
-                        let eval = confidence.getEvaluation(key: "swift-demoapp.color", defaultValue: "Gray")
+                        let client = OpenFeatureAPI.shared.getClient()
+                        let eval = client.getStringDetails(key: "swift-demoapp.color", defaultValue: "Gray")
+                        print("[Telemetry] Login flag eval: key=swift-demoapp.color value=\(eval.value) reason=\(eval.reason ?? "nil")")
                         flaggingState.color = ContentView.getColor(
                             color: eval.value
                         )
-                        flaggingState.reason = eval.reason
+                        flaggingState.reason = ResolveReason(rawValue: eval.reason ?? "") ?? .unknown
 
-                        // Simulating a module that handles feature flagging state during login
                         Task {
                             flaggingState.state = .loading
-                            try? await Task.sleep(nanoseconds: 5 * 1_000_000_000) // simulating network delay
-                            // putContext adds the user_id field to the evaluation context and fetches values for it
+                            try? await Task.sleep(nanoseconds: 5 * 1_000_000_000)
                             await confidence.putContextAndWait(context: ["user_id": .init(string: "user1")])
                             flaggingState.state = .ready
+                            print("[Telemetry] Context updated with user_id, flags refreshed")
                         }
 
-                        // Simulating a module that handles the actual login mechanism for a user
                         Task {
                             loggingIn = true
-                            try? await Task.sleep(nanoseconds: 1 * 1_000_000_000) // simulating network delay
+                            try? await Task.sleep(nanoseconds: 1 * 1_000_000_000)
                             loggedUser = "user1"
                             loggingIn = false
                             loginCompleted = true

--- a/Sources/Confidence/Apply/FlagApplierWithRetries.swift
+++ b/Sources/Confidence/Apply/FlagApplierWithRetries.swift
@@ -75,7 +75,6 @@ final class FlagApplierWithRetries: FlagApplier, TelemetryProducer {
             message: "Telemetry reported: \(errorCode.serialized) for flag '\(flagName)'",
             isWarning: false
         )
-        await triggerBatch()
     }
 
     func trackResolve(reason: ResolveReason) async {
@@ -85,6 +84,10 @@ final class FlagApplierWithRetries: FlagApplier, TelemetryProducer {
             message: "Telemetry trackResolve: \(reason.rawValue)",
             isWarning: false
         )
+    }
+
+    func flush() async {
+        await sendTelemetryCounters()
     }
 
     // MARK: Private

--- a/Sources/Confidence/Apply/FlagApplierWithRetries.swift
+++ b/Sources/Confidence/Apply/FlagApplierWithRetries.swift
@@ -1,34 +1,44 @@
 import Foundation
 import os
 
-typealias ApplyFlagHTTPResponse = HttpClientResponse<ApplyFlagsResponse>
-typealias ApplyFlagResult = Result<ApplyFlagHTTPResponse, Error>
+typealias FlagLogsHTTPResponse = HttpClientResponse<WriteFlagLogsResponse>
+typealias FlagLogsResult = Result<FlagLogsHTTPResponse, Error>
 
-final class FlagApplierWithRetries: FlagApplier {
-    private let storage: Storage
+final class FlagApplierWithRetries: FlagApplier, TelemetryProducer {
+    private let applyStorage: Storage
+    private let telemetryStorage: Storage
     private let httpClient: HttpClient
     private let options: ConfidenceClientOptions
     private let cacheDataInteractor: CacheDataActor
+    private let telemetryInteractor: TelemetryBatchActor
     private let metadata: ConfidenceMetadata
     private let debugLogger: DebugLogger?
 
     init(
         httpClient: HttpClient,
-        storage: Storage,
+        applyStorage: Storage,
+        telemetryStorage: Storage,
         options: ConfidenceClientOptions,
         metadata: ConfidenceMetadata,
         cacheDataInteractor: CacheDataActor? = nil,
+        telemetryInteractor: TelemetryBatchActor? = nil,
         triggerBatch: Bool = true,
         debugLogger: DebugLogger? = nil
     ) {
-        self.storage = storage
+        self.applyStorage = applyStorage
+        self.telemetryStorage = telemetryStorage
         self.httpClient = httpClient
         self.options = options
         self.metadata = metadata
         self.debugLogger = debugLogger
 
-        let storedData = try? storage.load(defaultValue: CacheData.empty())
-        self.cacheDataInteractor = cacheDataInteractor ?? CacheDataInteractor(cacheData: storedData ?? .empty())
+        let storedApplyData = try? applyStorage.load(defaultValue: CacheData.empty())
+        self.cacheDataInteractor = cacheDataInteractor
+            ?? CacheDataInteractor(cacheData: storedApplyData ?? .empty())
+
+        let storedTelemetry = try? telemetryStorage.load(defaultValue: TelemetryBatch.empty())
+        self.telemetryInteractor = telemetryInteractor
+            ?? TelemetryBatchInteractor(batch: storedTelemetry ?? .empty())
 
         if triggerBatch {
             Task {
@@ -36,6 +46,8 @@ final class FlagApplierWithRetries: FlagApplier {
             }
         }
     }
+
+    // MARK: FlagApplier
 
     public func apply(flagName: String, resolveToken: String) async {
         let applyTime = Date.backport.now
@@ -45,20 +57,41 @@ final class FlagApplierWithRetries: FlagApplier {
             applyTime: applyTime
         )
         guard added == true else {
-            // If record is found in the cache, early return (de-duplication).
-            // Triggerring batch apply in case if there are any unsent events stored
             await triggerBatch()
             return
         }
 
         debugLogger?.logFlags(action: "Apply", flag: flagName)
-        self.writeToFile(data: data)
+        writeApplyToFile(data: data)
         await triggerBatch()
     }
 
-    // MARK: private
+    // MARK: TelemetryProducer
+
+    func report(flagName: String, errorCode: ErrorCode, errorMessage: String?) async {
+        let entry = TelemetryEntry(
+            flagName: flagName,
+            errorCode: errorCode.serialized,
+            errorMessage: errorMessage,
+            time: Date.backport.now
+        )
+        let batch = await telemetryInteractor.add(entry: entry)
+        writeTelemetryToFile(batch: batch)
+        debugLogger?.logMessage(
+            message: "Telemetry reported: \(errorCode.serialized) for flag '\(flagName)'",
+            isWarning: false
+        )
+        await triggerBatch()
+    }
+
+    // MARK: Private
 
     private func triggerBatch() async {
+        await sendApplyBatches()
+        await sendTelemetryBatch()
+    }
+
+    private func sendApplyBatches() async {
         let cacheData = await cacheDataInteractor.cache
         await cacheData.resolveEvents.asyncForEach { resolveEvent in
             let appliesToSend = resolveEvent.events.filter { $0.status == .created }
@@ -69,22 +102,60 @@ final class FlagApplierWithRetries: FlagApplier {
             }
 
             await appliesToSend.asyncForEach { chunk in
-                await self.writeStatus(resolveToken: resolveEvent.resolveToken, events: chunk, status: .sending)
-                let success = await executeApply(
+                await self.writeApplyStatus(
+                    resolveToken: resolveEvent.resolveToken, events: chunk, status: .sending
+                )
+                let success = await self.executeFlagLogs(
                     resolveToken: resolveEvent.resolveToken,
                     items: chunk
                 )
                 guard success else {
-                    await self.writeStatus(resolveToken: resolveEvent.resolveToken, events: chunk, status: .created)
+                    await self.writeApplyStatus(
+                        resolveToken: resolveEvent.resolveToken, events: chunk, status: .created
+                    )
                     return
                 }
-                // Set 'sent' property of apply events to true
-                await self.writeStatus(resolveToken: resolveEvent.resolveToken, events: chunk, status: .sent)
+                await self.writeApplyStatus(
+                    resolveToken: resolveEvent.resolveToken, events: chunk, status: .sent
+                )
             }
         }
     }
 
-    private func writeStatus(resolveToken: String, events: [FlagApply], status: ApplyEventStatus) async {
+    private func sendTelemetryBatch() async {
+        let currentBatch = await telemetryInteractor.batch
+        let pending = currentBatch.entries.enumerated().filter { $0.element.status == .created }
+
+        guard !pending.isEmpty else { return }
+
+        let chunks = pending.chunk(size: 20)
+        for chunk in chunks {
+            let indices = chunk.map { $0.offset }
+            let entries = chunk.map { $0.element }
+
+            for index in indices {
+                _ = await telemetryInteractor.setStatus(at: index, status: .sending)
+            }
+
+            let success = await executeTelemetryOnly(entries: entries)
+            if success {
+                for index in indices {
+                    _ = await telemetryInteractor.setStatus(at: index, status: .sent)
+                }
+            } else {
+                for index in indices {
+                    _ = await telemetryInteractor.setStatus(at: index, status: .created)
+                }
+            }
+        }
+
+        let updatedBatch = await telemetryInteractor.removeCompleted()
+        writeTelemetryToFile(batch: updatedBatch)
+    }
+
+    private func writeApplyStatus(
+        resolveToken: String, events: [FlagApply], status: ApplyEventStatus
+    ) async {
         let lastIndex = events.count - 1
         await events.enumerated().asyncForEach { index, event in
             var data = await self.cacheDataInteractor.setEventStatus(
@@ -98,31 +169,42 @@ final class FlagApplierWithRetries: FlagApplier {
                     $0.isSent == false
                 }
                 data.resolveEvents = unsentFlagApplies
-                try? self.storage.save(data: data)
+                try? self.applyStorage.save(data: data)
             }
         }
     }
 
-    private func writeToFile(data: CacheData) {
-        try? storage.save(data: data)
+    private func writeApplyToFile(data: CacheData) {
+        try? applyStorage.save(data: data)
     }
 
-    private func executeApply(
+    private func writeTelemetryToFile(batch: TelemetryBatch) {
+        try? telemetryStorage.save(data: batch)
+    }
+
+    private func makeSdkInfo() -> SdkInfo {
+        SdkInfo(id: metadata.name, version: metadata.version)
+    }
+
+    private func executeFlagLogs(
         resolveToken: String,
         items: [FlagApply]
     ) async -> Bool {
-        let applyFlagRequestItems = items.map { applyEvent in
-            AppliedFlagRequestItem(
-                flag: applyEvent.name,
-                applyTime: applyEvent.applyTime
+        let appliedFlags = items.map { event in
+            AppliedFlag(
+                flag: "flags/\(event.name)",
+                applyTime: Date.backport.toISOString(date: event.applyTime)
             )
         }
-        let request = ApplyFlagsRequest(
-            flags: applyFlagRequestItems,
-            sendTime: Date.backport.nowISOString,
-            clientSecret: options.credentials.getSecret(),
-            resolveToken: resolveToken,
-            sdk: Sdk(id: metadata.name, version: metadata.version)
+        let sdkInfo = makeSdkInfo()
+        let flagAssigned = FlagAssignedEvent(
+            resolveId: resolveToken,
+            clientInfo: ClientInfo(sdk: sdkInfo),
+            flags: appliedFlags
+        )
+        let request = WriteFlagLogsRequest(
+            flagAssigned: [flagAssigned],
+            telemetryData: TelemetryData(sdk: sdkInfo)
         )
 
         let result = await performRequest(request: request)
@@ -130,16 +212,33 @@ final class FlagApplierWithRetries: FlagApplier {
         case .success:
             return true
         case .failure(let error):
-            self.logApplyError(error: error)
+            logError(error: error)
+            return false
+        }
+    }
+
+    private func executeTelemetryOnly(entries: [TelemetryEntry]) async -> Bool {
+        let sdkInfo = makeSdkInfo()
+        let request = WriteFlagLogsRequest(
+            flagAssigned: nil,
+            telemetryData: TelemetryData(sdk: sdkInfo)
+        )
+
+        let result = await performRequest(request: request)
+        switch result {
+        case .success:
+            return true
+        case .failure(let error):
+            logError(error: error)
             return false
         }
     }
 
     private func performRequest(
-        request: ApplyFlagsRequest
-    ) async -> ApplyFlagResult {
+        request: WriteFlagLogsRequest
+    ) async -> FlagLogsResult {
         do {
-            return try await httpClient.post(path: ":apply", data: request)
+            return try await httpClient.post(path: ":write", data: request)
         } catch {
             return .failure(handleError(error: error))
         }
@@ -153,8 +252,10 @@ final class FlagApplierWithRetries: FlagApplier {
         }
     }
 
-    private func logApplyError(error: Error) {
-        debugLogger?.logMessage(message: "Error while executing \"apply\": \(error)", isWarning: true)
+    private func logError(error: Error) {
+        debugLogger?.logMessage(
+            message: "Error while sending flag logs: \(error)", isWarning: true
+        )
     }
 }
 

--- a/Sources/Confidence/Apply/FlagApplierWithRetries.swift
+++ b/Sources/Confidence/Apply/FlagApplierWithRetries.swift
@@ -10,7 +10,7 @@ final class FlagApplierWithRetries: FlagApplier, TelemetryProducer {
     private let httpClient: HttpClient
     private let options: ConfidenceClientOptions
     private let cacheDataInteractor: CacheDataActor
-    private let telemetryInteractor: TelemetryBatchActor
+    private let telemetryCounters: TelemetryCounterActor
     private let metadata: ConfidenceMetadata
     private let debugLogger: DebugLogger?
 
@@ -21,7 +21,7 @@ final class FlagApplierWithRetries: FlagApplier, TelemetryProducer {
         options: ConfidenceClientOptions,
         metadata: ConfidenceMetadata,
         cacheDataInteractor: CacheDataActor? = nil,
-        telemetryInteractor: TelemetryBatchActor? = nil,
+        telemetryCounters: TelemetryCounterActor? = nil,
         triggerBatch: Bool = true,
         debugLogger: DebugLogger? = nil
     ) {
@@ -36,9 +36,9 @@ final class FlagApplierWithRetries: FlagApplier, TelemetryProducer {
         self.cacheDataInteractor = cacheDataInteractor
             ?? CacheDataInteractor(cacheData: storedApplyData ?? .empty())
 
-        let storedTelemetry = try? telemetryStorage.load(defaultValue: TelemetryBatch.empty())
-        self.telemetryInteractor = telemetryInteractor
-            ?? TelemetryBatchInteractor(batch: storedTelemetry ?? .empty())
+        let storedCounters = try? telemetryStorage.load(defaultValue: TelemetryCounterState.empty())
+        self.telemetryCounters = telemetryCounters
+            ?? TelemetryCounterInteractor(state: storedCounters ?? .empty())
 
         if triggerBatch {
             Task {
@@ -69,14 +69,8 @@ final class FlagApplierWithRetries: FlagApplier, TelemetryProducer {
     // MARK: TelemetryProducer
 
     func report(flagName: String, errorCode: ErrorCode, errorMessage: String?) async {
-        let entry = TelemetryEntry(
-            flagName: flagName,
-            errorCode: errorCode.serialized,
-            errorMessage: errorMessage,
-            time: Date.backport.now
-        )
-        let batch = await telemetryInteractor.add(entry: entry)
-        writeTelemetryToFile(batch: batch)
+        await telemetryCounters.recordClientError(errorCode: errorCode.serialized)
+        persistCounters()
         debugLogger?.logMessage(
             message: "Telemetry reported: \(errorCode.serialized) for flag '\(flagName)'",
             isWarning: false
@@ -84,11 +78,16 @@ final class FlagApplierWithRetries: FlagApplier, TelemetryProducer {
         await triggerBatch()
     }
 
+    func trackResolve(reason: ResolveReason) async {
+        await telemetryCounters.recordResolve(reason: reason.rawValue)
+        persistCounters()
+    }
+
     // MARK: Private
 
     private func triggerBatch() async {
         await sendApplyBatches()
-        await sendTelemetryBatch()
+        await sendTelemetryCounters()
     }
 
     private func sendApplyBatches() async {
@@ -122,35 +121,17 @@ final class FlagApplierWithRetries: FlagApplier, TelemetryProducer {
         }
     }
 
-    private func sendTelemetryBatch() async {
-        let currentBatch = await telemetryInteractor.batch
-        let pending = currentBatch.entries.enumerated().filter { $0.element.status == .created }
+    private func sendTelemetryCounters() async {
+        let snapshot = await telemetryCounters.drain()
+        guard !snapshot.isEmpty else { return }
 
-        guard !pending.isEmpty else { return }
-
-        let chunks = pending.chunk(size: 20)
-        for chunk in chunks {
-            let indices = chunk.map { $0.offset }
-            let entries = chunk.map { $0.element }
-
-            for index in indices {
-                _ = await telemetryInteractor.setStatus(at: index, status: .sending)
-            }
-
-            let success = await executeTelemetryOnly(entries: entries)
-            if success {
-                for index in indices {
-                    _ = await telemetryInteractor.setStatus(at: index, status: .sent)
-                }
-            } else {
-                for index in indices {
-                    _ = await telemetryInteractor.setStatus(at: index, status: .created)
-                }
-            }
+        let success = await executeTelemetryRequest(counters: snapshot)
+        if success {
+            persistCounters()
+        } else {
+            await telemetryCounters.restore(state: snapshot)
+            persistCounters()
         }
-
-        let updatedBatch = await telemetryInteractor.removeCompleted()
-        writeTelemetryToFile(batch: updatedBatch)
     }
 
     private func writeApplyStatus(
@@ -178,8 +159,11 @@ final class FlagApplierWithRetries: FlagApplier, TelemetryProducer {
         try? applyStorage.save(data: data)
     }
 
-    private func writeTelemetryToFile(batch: TelemetryBatch) {
-        try? telemetryStorage.save(data: batch)
+    private func persistCounters() {
+        Task {
+            let state = await telemetryCounters.currentState
+            try? telemetryStorage.save(data: state)
+        }
     }
 
     private func makeSdkInfo() -> SdkInfo {
@@ -217,11 +201,17 @@ final class FlagApplierWithRetries: FlagApplier, TelemetryProducer {
         }
     }
 
-    private func executeTelemetryOnly(entries: [TelemetryEntry]) async -> Bool {
+    private func executeTelemetryRequest(counters: TelemetryCounterState) async -> Bool {
         let sdkInfo = makeSdkInfo()
+        let resolveRate = counters.toResolveRateRecords()
+        let clientErrorRate = counters.toClientErrorRateRecords()
         let request = WriteFlagLogsRequest(
             flagAssigned: nil,
-            telemetryData: TelemetryData(sdk: sdkInfo)
+            telemetryData: TelemetryData(
+                sdk: sdkInfo,
+                resolveRate: resolveRate.isEmpty ? nil : resolveRate,
+                clientErrorRate: clientErrorRate.isEmpty ? nil : clientErrorRate
+            )
         )
 
         let result = await performRequest(request: request)

--- a/Sources/Confidence/Apply/FlagApplierWithRetries.swift
+++ b/Sources/Confidence/Apply/FlagApplierWithRetries.swift
@@ -81,6 +81,10 @@ final class FlagApplierWithRetries: FlagApplier, TelemetryProducer {
     func trackResolve(reason: ResolveReason) async {
         await telemetryCounters.recordResolve(reason: reason.rawValue)
         persistCounters()
+        debugLogger?.logMessage(
+            message: "Telemetry trackResolve: \(reason.rawValue)",
+            isWarning: false
+        )
     }
 
     // MARK: Private
@@ -227,11 +231,24 @@ final class FlagApplierWithRetries: FlagApplier, TelemetryProducer {
     private func performRequest(
         request: WriteFlagLogsRequest
     ) async -> FlagLogsResult {
+        logOutgoingRequest(request)
         do {
             return try await httpClient.post(path: ":write", data: request)
         } catch {
             return .failure(handleError(error: error))
         }
+    }
+
+    private func logOutgoingRequest(_ request: WriteFlagLogsRequest) {
+        guard debugLogger != nil else { return }
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        guard let data = try? encoder.encode(request),
+              let json = String(data: data, encoding: .utf8) else { return }
+        debugLogger?.logMessage(
+            message: "POST /v1/clientFlagLogs:write\n\(json)",
+            isWarning: false
+        )
     }
 
     private func handleError(error: Error) -> Error {

--- a/Sources/Confidence/BaseUrlMapper.swift
+++ b/Sources/Confidence/BaseUrlMapper.swift
@@ -11,4 +11,15 @@ public enum BaseUrlMapper {
             return "https://resolver.us.confidence.dev/v1/flags"
         }
     }
+
+    static func flagLogsUrl(region: ConfidenceRegion) -> String {
+        switch region {
+        case .global:
+            return "https://resolver.confidence.dev/v1/clientFlagLogs"
+        case .europe:
+            return "https://resolver.eu.confidence.dev/v1/clientFlagLogs"
+        case .usa:
+            return "https://resolver.us.confidence.dev/v1/clientFlagLogs"
+        }
+    }
 }

--- a/Sources/Confidence/Confidence.swift
+++ b/Sources/Confidence/Confidence.swift
@@ -109,6 +109,9 @@ public class Confidence: ConfidenceEventSender {
             resolveToken: resolvedFlags.resolveToken ?? ""
         )
         try storage.save(data: resolution)
+        for flag in resolvedFlags.resolvedValues {
+            await telemetryProducer?.trackResolve(reason: flag.resolveReason)
+        }
     }
 
     /**
@@ -135,7 +138,7 @@ public class Confidence: ConfidenceEventSender {
                     errorMessage: "Confidence instance deallocated before end of evaluation"
                 )
             }
-            let evaluation = self.cache.evaluate(
+            return self.cache.evaluate(
                 flagName: key,
                 defaultValue: defaultValue,
                 context: getContext(),
@@ -143,12 +146,6 @@ public class Confidence: ConfidenceEventSender {
                 telemetryProducer: telemetryProducer,
                 debugLogger: debugLogger
             )
-            if let telemetryProducer = self.telemetryProducer {
-                Task {
-                    await telemetryProducer.trackResolve(reason: evaluation.reason)
-                }
-            }
-            return evaluation
         }
     }
 

--- a/Sources/Confidence/Confidence.swift
+++ b/Sources/Confidence/Confidence.swift
@@ -135,7 +135,7 @@ public class Confidence: ConfidenceEventSender {
                     errorMessage: "Confidence instance deallocated before end of evaluation"
                 )
             }
-            return self.cache.evaluate(
+            let evaluation = self.cache.evaluate(
                 flagName: key,
                 defaultValue: defaultValue,
                 context: getContext(),
@@ -143,6 +143,12 @@ public class Confidence: ConfidenceEventSender {
                 telemetryProducer: telemetryProducer,
                 debugLogger: debugLogger
             )
+            if let telemetryProducer = self.telemetryProducer {
+                Task {
+                    await telemetryProducer.trackResolve(reason: evaluation.reason)
+                }
+            }
+            return evaluation
         }
     }
 

--- a/Sources/Confidence/Confidence.swift
+++ b/Sources/Confidence/Confidence.swift
@@ -109,9 +109,7 @@ public class Confidence: ConfidenceEventSender {
             resolveToken: resolvedFlags.resolveToken ?? ""
         )
         try storage.save(data: resolution)
-        for flag in resolvedFlags.resolvedValues {
-            await telemetryProducer?.trackResolve(reason: flag.resolveReason)
-        }
+        await telemetryProducer?.flush()
     }
 
     /**

--- a/Sources/Confidence/Confidence.swift
+++ b/Sources/Confidence/Confidence.swift
@@ -19,6 +19,7 @@ public class Confidence: ConfidenceEventSender {
     private let eventSenderEngine: EventSenderEngine
     private let storage: Storage
     private let flagApplier: FlagApplier
+    private let telemetryProducer: TelemetryProducer?
 
     // Synchronization and task management resources
     private var cancellables = Set<AnyCancellable>()
@@ -35,6 +36,7 @@ public class Confidence: ConfidenceEventSender {
         region: ConfidenceRegion,
         eventSenderEngine: EventSenderEngine,
         flagApplier: FlagApplier,
+        telemetryProducer: TelemetryProducer? = nil,
         remoteFlagResolver: ConfidenceResolveClient,
         storage: Storage,
         context: ConfidenceStruct = [:],
@@ -49,6 +51,7 @@ public class Confidence: ConfidenceEventSender {
         self.contextManager = ContextManager(initialContext: context)
         self.parentContextProvider = parent
         self.flagApplier = flagApplier
+        self.telemetryProducer = telemetryProducer
         self.remoteFlagResolver = remoteFlagResolver
         self.debugLogger = debugLogger
         if let visitorId {
@@ -137,6 +140,7 @@ public class Confidence: ConfidenceEventSender {
                 defaultValue: defaultValue,
                 context: getContext(),
                 flagApplier: flagApplier,
+                telemetryProducer: telemetryProducer,
                 debugLogger: debugLogger
             )
         }
@@ -280,6 +284,7 @@ public class Confidence: ConfidenceEventSender {
             region: region,
             eventSenderEngine: eventSenderEngine,
             flagApplier: flagApplier,
+            telemetryProducer: telemetryProducer,
             remoteFlagResolver: remoteFlagResolver,
             storage: storage,
             context: context,
@@ -477,17 +482,24 @@ extension Confidence {
                 metadata: metadata,
                 debugLogger: debugLogger
             )
-            let httpClient = NetworkClient(
-                baseUrl: BaseUrlMapper.from(region: options.region),
+            let flagLogsHttpClient = NetworkClient(
+                baseUrl: BaseUrlMapper.flagLogsUrl(region: options.region),
+                defaultHeaders: [
+                    "Authorization": "ClientSecret \(clientSecret)"
+                ],
                 timeoutIntervalForRequests: options.timeoutIntervalForRequest
             )
-            let flagApplier = flagApplier ?? FlagApplierWithRetries(
-                httpClient: httpClient,
-                storage: DefaultStorage(filePath: "confidence.flags.apply"),
+            let applierInstance = flagApplier as? FlagApplierWithRetries
+            let builtApplier = applierInstance ?? FlagApplierWithRetries(
+                httpClient: flagLogsHttpClient,
+                applyStorage: DefaultStorage(filePath: "confidence.flags.apply"),
+                telemetryStorage: DefaultStorage(filePath: "confidence.telemetry"),
                 options: options,
                 metadata: metadata,
                 debugLogger: debugLogger
             )
+            let flagApplier: FlagApplier = flagApplier ?? builtApplier
+            let telemetryProducer: TelemetryProducer = applierInstance ?? builtApplier
             let flagResolver = flagResolver ?? RemoteConfidenceResolveClient(
                 options: options,
                 applyOnResolve: false,
@@ -504,6 +516,7 @@ extension Confidence {
                 region: region,
                 eventSenderEngine: eventSenderEngine,
                 flagApplier: flagApplier,
+                telemetryProducer: telemetryProducer,
                 remoteFlagResolver: flagResolver,
                 storage: storage ?? DefaultStorage(filePath: "confidence.flags.resolve"),
                 context: initialContext,

--- a/Sources/Confidence/FlagEvaluation.swift
+++ b/Sources/Confidence/FlagEvaluation.swift
@@ -85,6 +85,7 @@ extension FlagResolution {
                 Task {
                     if resolvedFlag.shouldApply {
                         await flagApplier?.apply(flagName: parsedKey.flag, resolveToken: self.resolveToken)
+                        await telemetryProducer?.trackResolve(reason: resolvedFlag.resolveReason)
                     }
                 }
                 return Evaluation(
@@ -103,18 +104,12 @@ extension FlagResolution {
                 var resolveReason: ResolveReason = .match
                 if self.context != context {
                     resolveReason = .stale
-                    Task {
-                        await telemetryProducer?.report(
-                            flagName: parsedKey.flag,
-                            errorCode: .evaluationError,
-                            errorMessage: "Stale evaluation: context changed since last resolve"
-                        )
-                    }
                 }
                 if let typedValue = typedValue {
                     Task {
                         if resolvedFlag.shouldApply {
                             await flagApplier?.apply(flagName: parsedKey.flag, resolveToken: self.resolveToken)
+                            await telemetryProducer?.trackResolve(reason: resolveReason)
                         }
                     }
                     return Evaluation(
@@ -129,6 +124,7 @@ extension FlagResolution {
                         Task {
                             if resolvedFlag.shouldApply {
                                 await flagApplier?.apply(flagName: parsedKey.flag, resolveToken: self.resolveToken)
+                                await telemetryProducer?.trackResolve(reason: resolveReason)
                             }
                         }
                         return Evaluation(
@@ -158,6 +154,7 @@ extension FlagResolution {
                 Task {
                     if resolvedFlag.shouldApply {
                         await flagApplier?.apply(flagName: parsedKey.flag, resolveToken: self.resolveToken)
+                        await telemetryProducer?.trackResolve(reason: resolvedFlag.resolveReason)
                     }
                 }
                 return Evaluation(

--- a/Sources/Confidence/FlagEvaluation.swift
+++ b/Sources/Confidence/FlagEvaluation.swift
@@ -103,6 +103,13 @@ extension FlagResolution {
                 var resolveReason: ResolveReason = .match
                 if self.context != context {
                     resolveReason = .stale
+                    Task {
+                        await telemetryProducer?.report(
+                            flagName: parsedKey.flag,
+                            errorCode: .evaluationError,
+                            errorMessage: "Stale evaluation: context changed since last resolve"
+                        )
+                    }
                 }
                 if let typedValue = typedValue {
                     Task {

--- a/Sources/Confidence/FlagEvaluation.swift
+++ b/Sources/Confidence/FlagEvaluation.swift
@@ -16,6 +16,18 @@ public enum ErrorCode: Equatable {
     case parseError(message: String)
     case typeMismatch(message: String = "Mismatch between default value and flag value type")
     case generalError(message: String)
+
+    var serialized: String {
+        switch self {
+        case .providerNotReady: return "PROVIDER_NOT_READY"
+        case .invalidContext: return "INVALID_CONTEXT"
+        case .flagNotFound: return "FLAG_NOT_FOUND"
+        case .evaluationError: return "EVALUATION_ERROR"
+        case .parseError: return "PARSE_ERROR"
+        case .typeMismatch: return "TYPE_MISMATCH"
+        case .generalError: return "GENERAL_ERROR"
+        }
+    }
 }
 
 struct FlagResolution: Encodable, Decodable, Equatable {
@@ -33,18 +45,26 @@ extension FlagResolution {
         defaultValue: T,
         context: ConfidenceStruct,
         flagApplier: FlagApplier? = nil,
+        telemetryProducer: TelemetryProducer? = nil,
         debugLogger: DebugLogger? = nil
     ) -> Evaluation<T> {
         do {
             let parsedKey = try FlagPath.getPath(for: flagName)
             let resolvedFlag = self.flags.first { resolvedFlag in resolvedFlag.flag == parsedKey.flag }
             guard let resolvedFlag = resolvedFlag else {
+                let errorCode: ErrorCode = .flagNotFound
+                let errorMessage = "Flag '\(parsedKey.flag)' not found in local cache"
+                Task {
+                    await telemetryProducer?.report(
+                        flagName: parsedKey.flag, errorCode: errorCode, errorMessage: errorMessage
+                    )
+                }
                 return Evaluation(
                     value: defaultValue,
                     variant: nil,
                     reason: .error,
-                    errorCode: .flagNotFound,
-                    errorMessage: "Flag '\(parsedKey.flag)' not found in local cache"
+                    errorCode: errorCode,
+                    errorMessage: errorMessage
                 )
             }
 
@@ -52,12 +72,16 @@ extension FlagResolution {
                 debugLogger.logResolveDebugURL(flagName: parsedKey.flag, context: context)
             }
 
-            if let evaluation = checkBackendErrors(resolvedFlag: resolvedFlag, defaultValue: defaultValue) {
+            if let evaluation = checkBackendErrors(
+                resolvedFlag: resolvedFlag,
+                defaultValue: defaultValue,
+                flagName: parsedKey.flag,
+                telemetryProducer: telemetryProducer
+            ) {
                 return evaluation
             }
 
             guard let value = resolvedFlag.value else {
-                // No backend error, but nil value returned. This can happend with "noSegmentMatch" or "archived", for example
                 Task {
                     if resolvedFlag.shouldApply {
                         await flagApplier?.apply(flagName: parsedKey.flag, resolveToken: self.resolveToken)
@@ -94,7 +118,6 @@ extension FlagResolution {
                         errorMessage: nil
                     )
                 } else {
-                    // `null` type from backend instructs to use client-side default value
                     if parsedValue == .init(null: ()) {
                         Task {
                             if resolvedFlag.shouldApply {
@@ -109,11 +132,17 @@ extension FlagResolution {
                             errorMessage: nil
                         )
                     } else {
+                        let errorCode: ErrorCode = .typeMismatch()
+                        Task {
+                            await telemetryProducer?.report(
+                                flagName: parsedKey.flag, errorCode: errorCode, errorMessage: nil
+                            )
+                        }
                         return Evaluation(
                             value: defaultValue,
                             variant: nil,
                             reason: .error,
-                            errorCode: .typeMismatch(),
+                            errorCode: errorCode,
                             errorMessage: nil
                         )
                     }
@@ -133,44 +162,77 @@ extension FlagResolution {
                 )
             }
         } catch let error as ConfidenceError {
+            let errorCode = error.errorCode
+            let errorMessage = error.description
+            Task {
+                await telemetryProducer?.report(
+                    flagName: flagName, errorCode: errorCode, errorMessage: errorMessage
+                )
+            }
             return Evaluation(
                 value: defaultValue,
                 variant: nil,
                 reason: .error,
-                errorCode: error.errorCode,
-                errorMessage: error.description
+                errorCode: errorCode,
+                errorMessage: errorMessage
             )
         } catch {
+            let errorCode: ErrorCode = .evaluationError
+            let errorMessage = error.localizedDescription
+            Task {
+                await telemetryProducer?.report(
+                    flagName: flagName, errorCode: errorCode, errorMessage: errorMessage
+                )
+            }
             return Evaluation(
                 value: defaultValue,
                 variant: nil,
                 reason: .error,
-                errorCode: .evaluationError,
-                errorMessage: error.localizedDescription
+                errorCode: errorCode,
+                errorMessage: errorMessage
             )
         }
     }
     // swiftlint:enable function_body_length
     // swiftlint:enable cyclomatic_complexity
 
-    private func checkBackendErrors<T>(resolvedFlag: ResolvedValue, defaultValue: T) -> Evaluation<T>? {
+    private func checkBackendErrors<T>(
+        resolvedFlag: ResolvedValue,
+        defaultValue: T,
+        flagName: String,
+        telemetryProducer: TelemetryProducer?
+    ) -> Evaluation<T>? {
         if resolvedFlag.resolveReason == .targetingKeyError {
+            let errorCode: ErrorCode = .invalidContext
+            let errorMessage = "Invalid targeting key"
+            Task {
+                await telemetryProducer?.report(
+                    flagName: flagName, errorCode: errorCode, errorMessage: errorMessage
+                )
+            }
             return Evaluation(
                 value: defaultValue,
                 variant: nil,
                 reason: .targetingKeyError,
-                errorCode: .invalidContext,
-                errorMessage: "Invalid targeting key"
+                errorCode: errorCode,
+                errorMessage: errorMessage
             )
         } else if resolvedFlag.resolveReason == .error ||
         resolvedFlag.resolveReason == .unknown ||
         resolvedFlag.resolveReason == .unspecified {
+            let errorCode: ErrorCode = .evaluationError
+            let errorMessage = "Unknown error from backend"
+            Task {
+                await telemetryProducer?.report(
+                    flagName: flagName, errorCode: errorCode, errorMessage: errorMessage
+                )
+            }
             return Evaluation(
                 value: defaultValue,
                 variant: nil,
                 reason: .error,
-                errorCode: .evaluationError,
-                errorMessage: "Unknown error from backend"
+                errorCode: errorCode,
+                errorMessage: errorMessage
             )
         } else {
             return nil

--- a/Sources/Confidence/Http/NetworkClient.swift
+++ b/Sources/Confidence/Http/NetworkClient.swift
@@ -107,6 +107,10 @@ extension NetworkClient {
         request.addValue("application/json", forHTTPHeaderField: "Content-Type")
         request.addValue("application/json", forHTTPHeaderField: "Accept")
 
+        for (key, value) in headers {
+            request.addValue(value, forHTTPHeaderField: key)
+        }
+
         let encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
 

--- a/Sources/Confidence/RemoteResolveConfidenceClient.swift
+++ b/Sources/Confidence/RemoteResolveConfidenceClient.swift
@@ -130,27 +130,6 @@ public enum ResolveReason: String, Codable, CaseIterableDefaultsLast {
     case unknown
 }
 
-struct AppliedFlagRequestItem: Codable {
-    let flag: String
-    let applyTime: String
-
-    init(flag: String, applyTime: Date) {
-        self.flag = "flags/\(flag)"
-        self.applyTime = Date.backport.toISOString(date: applyTime)
-    }
-}
-
-struct ApplyFlagsRequest: Codable {
-    var flags: [AppliedFlagRequestItem]
-    var sendTime: String
-    var clientSecret: String
-    var resolveToken: String
-    var sdk: Sdk
-}
-
-struct ApplyFlagsResponse: Codable {
-}
-
 private func displayName(resolvedFlag: ResolvedFlag) throws -> String {
     let flagNameComponents = resolvedFlag.flag.components(separatedBy: "/")
     if flagNameComponents.count <= 1 || flagNameComponents[0] != "flags" {

--- a/Sources/Confidence/Telemetry/TelemetryProducer.swift
+++ b/Sources/Confidence/Telemetry/TelemetryProducer.swift
@@ -2,4 +2,5 @@ import Foundation
 
 protocol TelemetryProducer {
     func report(flagName: String, errorCode: ErrorCode, errorMessage: String?) async
+    func trackResolve(reason: ResolveReason) async
 }

--- a/Sources/Confidence/Telemetry/TelemetryProducer.swift
+++ b/Sources/Confidence/Telemetry/TelemetryProducer.swift
@@ -3,4 +3,5 @@ import Foundation
 protocol TelemetryProducer {
     func report(flagName: String, errorCode: ErrorCode, errorMessage: String?) async
     func trackResolve(reason: ResolveReason) async
+    func flush() async
 }

--- a/Sources/Confidence/Telemetry/TelemetryProducer.swift
+++ b/Sources/Confidence/Telemetry/TelemetryProducer.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+protocol TelemetryProducer {
+    func report(flagName: String, errorCode: ErrorCode, errorMessage: String?) async
+}

--- a/Sources/Confidence/Telemetry/TelemetryStorage.swift
+++ b/Sources/Confidence/Telemetry/TelemetryStorage.swift
@@ -1,0 +1,86 @@
+import Foundation
+
+struct TelemetryEntry: Codable {
+    let flagName: String
+    let errorCode: String
+    let errorMessage: String?
+    let time: Date
+    var status: ApplyEventStatus
+
+    init(
+        flagName: String,
+        errorCode: String,
+        errorMessage: String?,
+        time: Date,
+        status: ApplyEventStatus = .created
+    ) {
+        self.flagName = flagName
+        self.errorCode = errorCode
+        self.errorMessage = errorMessage
+        self.time = time
+        self.status = status
+    }
+}
+
+struct TelemetryBatch: Codable {
+    var entries: [TelemetryEntry]
+
+    var isEmpty: Bool {
+        entries.isEmpty
+    }
+
+    static func empty() -> TelemetryBatch {
+        TelemetryBatch(entries: [])
+    }
+
+    static func convertInTransit(batch: TelemetryBatch) -> TelemetryBatch {
+        var mutated = batch
+        for index in 0..<mutated.entries.count where mutated.entries[index].status == .sending {
+            mutated.entries[index].status = .created
+        }
+        return mutated
+    }
+
+    mutating func add(entry: TelemetryEntry) {
+        entries.append(entry)
+    }
+
+    mutating func setStatus(at index: Int, status: ApplyEventStatus) {
+        guard index < entries.count else { return }
+        entries[index].status = status
+    }
+
+    mutating func removeCompleted() {
+        entries.removeAll { $0.status == .sent }
+    }
+}
+
+protocol TelemetryBatchActor: Actor {
+    var batch: TelemetryBatch { get }
+    func add(entry: TelemetryEntry) -> TelemetryBatch
+    func setStatus(at index: Int, status: ApplyEventStatus) -> TelemetryBatch
+    func removeCompleted() -> TelemetryBatch
+}
+
+final actor TelemetryBatchInteractor: TelemetryBatchActor {
+    var batch: TelemetryBatch
+
+    init(batch: TelemetryBatch) {
+        self.batch = TelemetryBatch.convertInTransit(batch: batch)
+    }
+
+    func add(entry: TelemetryEntry) -> TelemetryBatch {
+        batch.add(entry: entry)
+        return batch
+    }
+
+    func setStatus(at index: Int, status: ApplyEventStatus) -> TelemetryBatch {
+        batch.setStatus(at: index, status: status)
+        return batch
+    }
+
+    func removeCompleted() -> TelemetryBatch {
+        batch.removeCompleted()
+        return batch
+    }
+}

--- a/Sources/Confidence/Telemetry/TelemetryStorage.swift
+++ b/Sources/Confidence/Telemetry/TelemetryStorage.swift
@@ -1,86 +1,65 @@
 import Foundation
 
-struct TelemetryEntry: Codable {
-    let flagName: String
-    let errorCode: String
-    let errorMessage: String?
-    let time: Date
-    var status: ApplyEventStatus
+struct TelemetryCounterState: Codable {
+    var resolveRates: [String: UInt32]
+    var clientErrors: [String: UInt32]
 
-    init(
-        flagName: String,
-        errorCode: String,
-        errorMessage: String?,
-        time: Date,
-        status: ApplyEventStatus = .created
-    ) {
-        self.flagName = flagName
-        self.errorCode = errorCode
-        self.errorMessage = errorMessage
-        self.time = time
-        self.status = status
+    static func empty() -> TelemetryCounterState {
+        TelemetryCounterState(resolveRates: [:], clientErrors: [:])
     }
-}
-
-struct TelemetryBatch: Codable {
-    var entries: [TelemetryEntry]
 
     var isEmpty: Bool {
-        entries.isEmpty
+        resolveRates.isEmpty && clientErrors.isEmpty
     }
 
-    static func empty() -> TelemetryBatch {
-        TelemetryBatch(entries: [])
+    func toResolveRateRecords() -> [ResolveRateRecord] {
+        resolveRates.map { ResolveRateRecord(count: $0.value, reason: $0.key) }
+            .sorted { $0.reason < $1.reason }
     }
 
-    static func convertInTransit(batch: TelemetryBatch) -> TelemetryBatch {
-        var mutated = batch
-        for index in 0..<mutated.entries.count where mutated.entries[index].status == .sending {
-            mutated.entries[index].status = .created
+    func toClientErrorRateRecords() -> [ClientErrorRateRecord] {
+        clientErrors.map { ClientErrorRateRecord(count: $0.value, errorCode: $0.key) }
+            .sorted { $0.errorCode < $1.errorCode }
+    }
+}
+
+protocol TelemetryCounterActor: Actor {
+    var currentState: TelemetryCounterState { get }
+    func recordResolve(reason: String)
+    func recordClientError(errorCode: String)
+    func drain() -> TelemetryCounterState
+    func restore(state: TelemetryCounterState)
+}
+
+final actor TelemetryCounterInteractor: TelemetryCounterActor {
+    private var state: TelemetryCounterState
+
+    var currentState: TelemetryCounterState { state }
+
+    init(state: TelemetryCounterState) {
+        self.state = state
+    }
+
+    func recordResolve(reason: String) {
+        state.resolveRates[reason, default: 0] += 1
+    }
+
+    func recordClientError(errorCode: String) {
+        state.clientErrors[errorCode, default: 0] += 1
+    }
+
+    func drain() -> TelemetryCounterState {
+        let snapshot = state
+        state = .empty()
+        return snapshot
+    }
+
+    func restore(state: TelemetryCounterState) {
+        for (key, count) in state.resolveRates {
+            self.state.resolveRates[key, default: 0] += count
         }
-        return mutated
-    }
-
-    mutating func add(entry: TelemetryEntry) {
-        entries.append(entry)
-    }
-
-    mutating func setStatus(at index: Int, status: ApplyEventStatus) {
-        guard index < entries.count else { return }
-        entries[index].status = status
-    }
-
-    mutating func removeCompleted() {
-        entries.removeAll { $0.status == .sent }
-    }
-}
-
-protocol TelemetryBatchActor: Actor {
-    var batch: TelemetryBatch { get }
-    func add(entry: TelemetryEntry) -> TelemetryBatch
-    func setStatus(at index: Int, status: ApplyEventStatus) -> TelemetryBatch
-    func removeCompleted() -> TelemetryBatch
-}
-
-final actor TelemetryBatchInteractor: TelemetryBatchActor {
-    var batch: TelemetryBatch
-
-    init(batch: TelemetryBatch) {
-        self.batch = TelemetryBatch.convertInTransit(batch: batch)
-    }
-
-    func add(entry: TelemetryEntry) -> TelemetryBatch {
-        batch.add(entry: entry)
-        return batch
-    }
-
-    func setStatus(at index: Int, status: ApplyEventStatus) -> TelemetryBatch {
-        batch.setStatus(at: index, status: status)
-        return batch
-    }
-
-    func removeCompleted() -> TelemetryBatch {
-        batch.removeCompleted()
-        return batch
+        for (key, count) in state.clientErrors {
+            self.state.clientErrors[key, default: 0] += count
+        }
     }
 }

--- a/Sources/Confidence/Telemetry/WriteFlagLogsModels.swift
+++ b/Sources/Confidence/Telemetry/WriteFlagLogsModels.swift
@@ -27,6 +27,18 @@ struct SdkInfo: Codable {
 
 struct TelemetryData: Codable {
     var sdk: SdkInfo?
+    var resolveRate: [ResolveRateRecord]?
+    var clientErrorRate: [ClientErrorRateRecord]?
+}
+
+struct ResolveRateRecord: Codable, Equatable {
+    var count: UInt32
+    var reason: String
+}
+
+struct ClientErrorRateRecord: Codable, Equatable {
+    var count: UInt32
+    var errorCode: String
 }
 
 struct WriteFlagLogsResponse: Codable {}

--- a/Sources/Confidence/Telemetry/WriteFlagLogsModels.swift
+++ b/Sources/Confidence/Telemetry/WriteFlagLogsModels.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+struct WriteFlagLogsRequest: Codable {
+    var flagAssigned: [FlagAssignedEvent]?
+    var telemetryData: TelemetryData?
+}
+
+struct FlagAssignedEvent: Codable {
+    var resolveId: String
+    var clientInfo: ClientInfo
+    var flags: [AppliedFlag]
+}
+
+struct AppliedFlag: Codable {
+    var flag: String
+    var applyTime: String
+}
+
+struct ClientInfo: Codable {
+    var sdk: SdkInfo
+}
+
+struct SdkInfo: Codable {
+    var id: String
+    var version: String
+}
+
+struct TelemetryData: Codable {
+    var sdk: SdkInfo?
+}
+
+struct WriteFlagLogsResponse: Codable {}

--- a/Tests/ConfidenceTests/FlagApplierWithRetriesTest.swift
+++ b/Tests/ConfidenceTests/FlagApplierWithRetriesTest.swift
@@ -523,7 +523,7 @@ class FlagApplierWithRetriesTest: XCTestCase {
 
     // MARK: Telemetry counters
 
-    func testTelemetry_reportIncrementsErrorCounterAndSends() async throws {
+    func testTelemetry_reportAccumulatesThenFlushSends() async throws {
         let counters = TelemetryCounterInteractor(state: .empty())
         let applier = FlagApplierWithRetries(
             httpClient: httpClient,
@@ -540,6 +540,12 @@ class FlagApplierWithRetriesTest: XCTestCase {
             errorCode: .flagNotFound,
             errorMessage: "Flag 'missing-flag' not found"
         )
+
+        // report() does not send
+        XCTAssertEqual(httpClient.postCallCounter, 0)
+
+        // flush() sends accumulated counters
+        await applier.flush()
 
         XCTAssertGreaterThanOrEqual(httpClient.postCallCounter, 1)
 
@@ -592,9 +598,10 @@ class FlagApplierWithRetriesTest: XCTestCase {
         await applier.trackResolve(reason: .match)
         await applier.trackResolve(reason: .match)
         await applier.trackResolve(reason: .stale)
-
-        // Trigger a batch via report (which also adds a client error)
         await applier.report(flagName: "test", errorCode: .evaluationError, errorMessage: nil)
+
+        // flush() sends accumulated telemetry counters
+        await applier.flush()
 
         let request = try XCTUnwrap(httpClient.data?.last as? WriteFlagLogsRequest)
         let resolveRates = try XCTUnwrap(request.telemetryData?.resolveRate)
@@ -609,11 +616,10 @@ class FlagApplierWithRetriesTest: XCTestCase {
         XCTAssertTrue(state.isEmpty)
     }
 
-    func testTelemetry_reportOffline_persistsCounters() async throws {
-        let offlineClient = HttpClientMock(testMode: .offline)
+    func testTelemetry_reportAccumulatesWithoutSending() async throws {
         let counters = TelemetryCounterInteractor(state: .empty())
         let applier = FlagApplierWithRetries(
-            httpClient: offlineClient,
+            httpClient: httpClient,
             applyStorage: applyStorage,
             telemetryStorage: telemetryStorage,
             options: options,
@@ -628,7 +634,29 @@ class FlagApplierWithRetriesTest: XCTestCase {
             errorMessage: nil
         )
 
-        // On failure, counters are restored
+        // report() accumulates counters but does not trigger a network request
+        let state = await counters.currentState
+        XCTAssertEqual(state.clientErrors["TYPE_MISMATCH"], 1)
+        XCTAssertEqual(httpClient.postCallCounter, 0)
+    }
+
+    func testTelemetry_flushOffline_restoresCounters() async throws {
+        let offlineClient = HttpClientMock(testMode: .offline)
+        let counters = TelemetryCounterInteractor(state: .empty())
+        let applier = FlagApplierWithRetries(
+            httpClient: offlineClient,
+            applyStorage: applyStorage,
+            telemetryStorage: telemetryStorage,
+            options: options,
+            metadata: metadata,
+            telemetryCounters: counters,
+            triggerBatch: false
+        )
+
+        await applier.report(flagName: "my-flag", errorCode: .typeMismatch(), errorMessage: nil)
+        await applier.flush()
+
+        // On flush failure, counters are restored
         let state = await counters.currentState
         XCTAssertEqual(state.clientErrors["TYPE_MISMATCH"], 1)
     }

--- a/Tests/ConfidenceTests/FlagApplierWithRetriesTest.swift
+++ b/Tests/ConfidenceTests/FlagApplierWithRetriesTest.swift
@@ -521,15 +521,17 @@ class FlagApplierWithRetriesTest: XCTestCase {
         XCTAssertEqual(request.telemetryData?.sdk?.id, metadata.name)
     }
 
-    // MARK: Telemetry
+    // MARK: Telemetry counters
 
-    func testTelemetry_reportStoresAndSends() async throws {
+    func testTelemetry_reportIncrementsErrorCounterAndSends() async throws {
+        let counters = TelemetryCounterInteractor(state: .empty())
         let applier = FlagApplierWithRetries(
             httpClient: httpClient,
             applyStorage: applyStorage,
             telemetryStorage: telemetryStorage,
             options: options,
             metadata: metadata,
+            telemetryCounters: counters,
             triggerBatch: false
         )
 
@@ -539,18 +541,84 @@ class FlagApplierWithRetriesTest: XCTestCase {
             errorMessage: "Flag 'missing-flag' not found"
         )
 
-        // The report triggers a batch that sends telemetry-only request
         XCTAssertGreaterThanOrEqual(httpClient.postCallCounter, 1)
+
+        let request = try XCTUnwrap(httpClient.data?.last as? WriteFlagLogsRequest)
+        XCTAssertNil(request.flagAssigned)
+        XCTAssertNotNil(request.telemetryData?.clientErrorRate)
+
+        let errorRates = try XCTUnwrap(request.telemetryData?.clientErrorRate)
+        XCTAssertEqual(errorRates.count, 1)
+        XCTAssertEqual(errorRates.first?.errorCode, "FLAG_NOT_FOUND")
+        XCTAssertEqual(errorRates.first?.count, 1)
     }
 
-    func testTelemetry_reportOffline_persistsToDisk() async throws {
+    func testTelemetry_trackResolveIncrementsCounter() async throws {
+        let counters = TelemetryCounterInteractor(state: .empty())
+        let applier = FlagApplierWithRetries(
+            httpClient: httpClient,
+            applyStorage: applyStorage,
+            telemetryStorage: telemetryStorage,
+            options: options,
+            metadata: metadata,
+            telemetryCounters: counters,
+            triggerBatch: false
+        )
+
+        await applier.trackResolve(reason: .match)
+        await applier.trackResolve(reason: .match)
+        await applier.trackResolve(reason: .noSegmentMatch)
+
+        let state = await counters.currentState
+        XCTAssertEqual(state.resolveRates["RESOLVE_REASON_MATCH"], 2)
+        XCTAssertEqual(state.resolveRates["RESOLVE_REASON_NO_SEGMENT_MATCH"], 1)
+
+        // trackResolve does not trigger a batch
+        XCTAssertEqual(httpClient.postCallCounter, 0)
+    }
+
+    func testTelemetry_countersIncludedInTelemetryRequest() async throws {
+        let counters = TelemetryCounterInteractor(state: .empty())
+        let applier = FlagApplierWithRetries(
+            httpClient: httpClient,
+            applyStorage: applyStorage,
+            telemetryStorage: telemetryStorage,
+            options: options,
+            metadata: metadata,
+            telemetryCounters: counters,
+            triggerBatch: false
+        )
+
+        await applier.trackResolve(reason: .match)
+        await applier.trackResolve(reason: .match)
+        await applier.trackResolve(reason: .stale)
+
+        // Trigger a batch via report (which also adds a client error)
+        await applier.report(flagName: "test", errorCode: .evaluationError, errorMessage: nil)
+
+        let request = try XCTUnwrap(httpClient.data?.last as? WriteFlagLogsRequest)
+        let resolveRates = try XCTUnwrap(request.telemetryData?.resolveRate)
+        let errorRates = try XCTUnwrap(request.telemetryData?.clientErrorRate)
+
+        XCTAssertTrue(resolveRates.contains(ResolveRateRecord(count: 2, reason: "RESOLVE_REASON_MATCH")))
+        XCTAssertTrue(resolveRates.contains(ResolveRateRecord(count: 1, reason: "RESOLVE_REASON_STALE")))
+        XCTAssertTrue(errorRates.contains(ClientErrorRateRecord(count: 1, errorCode: "EVALUATION_ERROR")))
+
+        // After successful send, counters should be drained
+        let state = await counters.currentState
+        XCTAssertTrue(state.isEmpty)
+    }
+
+    func testTelemetry_reportOffline_persistsCounters() async throws {
         let offlineClient = HttpClientMock(testMode: .offline)
+        let counters = TelemetryCounterInteractor(state: .empty())
         let applier = FlagApplierWithRetries(
             httpClient: offlineClient,
             applyStorage: applyStorage,
             telemetryStorage: telemetryStorage,
             options: options,
             metadata: metadata,
+            telemetryCounters: counters,
             triggerBatch: false
         )
 
@@ -560,31 +628,31 @@ class FlagApplierWithRetriesTest: XCTestCase {
             errorMessage: nil
         )
 
-        let batch = try telemetryStorage.load(defaultValue: TelemetryBatch.empty())
-        XCTAssertEqual(batch.entries.count, 1)
-        XCTAssertEqual(batch.entries.first?.flagName, "my-flag")
-        XCTAssertEqual(batch.entries.first?.errorCode, "TYPE_MISMATCH")
+        // On failure, counters are restored
+        let state = await counters.currentState
+        XCTAssertEqual(state.clientErrors["TYPE_MISMATCH"], 1)
     }
 
-    func testTelemetry_multipleReports_noDeduplcation() async throws {
+    func testTelemetry_multipleErrors_aggregated() async throws {
+        let counters = TelemetryCounterInteractor(state: .empty())
         let offlineClient = HttpClientMock(testMode: .offline)
-        let telemetryInteractor = TelemetryBatchInteractor(batch: .empty())
         let applier = FlagApplierWithRetries(
             httpClient: offlineClient,
             applyStorage: applyStorage,
             telemetryStorage: telemetryStorage,
             options: options,
             metadata: metadata,
-            telemetryInteractor: telemetryInteractor,
+            telemetryCounters: counters,
             triggerBatch: false
         )
 
         await applier.report(flagName: "flag1", errorCode: .flagNotFound, errorMessage: nil)
-        await applier.report(flagName: "flag1", errorCode: .flagNotFound, errorMessage: nil)
-        await applier.report(flagName: "flag1", errorCode: .flagNotFound, errorMessage: nil)
+        await applier.report(flagName: "flag2", errorCode: .flagNotFound, errorMessage: nil)
+        await applier.report(flagName: "flag3", errorCode: .typeMismatch(), errorMessage: nil)
 
-        let batch = await telemetryInteractor.batch
-        XCTAssertEqual(batch.entries.count, 3)
+        let state = await counters.currentState
+        XCTAssertEqual(state.clientErrors["FLAG_NOT_FOUND"], 2)
+        XCTAssertEqual(state.clientErrors["TYPE_MISMATCH"], 1)
     }
 
     private func hundredApplyCalls(applier: FlagApplier, sameToken: Bool = false) async {

--- a/Tests/ConfidenceTests/FlagApplierWithRetriesTest.swift
+++ b/Tests/ConfidenceTests/FlagApplierWithRetriesTest.swift
@@ -1,7 +1,6 @@
 // swiftlint:disable type_body_length
 // swiftlint:disable file_length
 import Foundation
-import OpenFeature
 import XCTest
 
 @testable import Confidence
@@ -12,78 +11,82 @@ class FlagApplierWithRetriesTest: XCTestCase {
         credentials: .clientSecret(secret: "test"),
         timeoutIntervalForRequest: 10
     )
-    private var storage = StorageMock()
+    private var applyStorage = StorageMock()
+    private var telemetryStorage = StorageMock()
     private var httpClient = HttpClientMock()
     private let metadata = ConfidenceMetadata(name: "test-provider-name", version: "0.0.0.")
 
     override func setUp() {
-        storage = StorageMock()
+        applyStorage = StorageMock()
+        telemetryStorage = StorageMock()
         httpClient = HttpClientMock()
 
         super.setUp()
     }
 
     func testApply_differentTokens() async {
-        // Given flag applier
         let applier = FlagApplierWithRetries(
-            httpClient: httpClient, storage: storage, options: options, metadata: metadata, triggerBatch: false
+            httpClient: httpClient,
+            applyStorage: applyStorage,
+            telemetryStorage: telemetryStorage,
+            options: options,
+            metadata: metadata,
+            triggerBatch: false
         )
 
-        // When 3 apply calls are issued with different tokens
         await applier.apply(flagName: "flag1", resolveToken: "token1")
         await applier.apply(flagName: "flag1", resolveToken: "token2")
         await applier.apply(flagName: "flag1", resolveToken: "token3")
 
-        // Then http client sends 3 post requests
         XCTAssertEqual(httpClient.postCallCounter, 3)
     }
 
     func testApply_duplicateEventsAreNotSent() async {
-        // Given flag applier
         let applier = FlagApplierWithRetries(
-            httpClient: httpClient, storage: storage, options: options, metadata: metadata, triggerBatch: false
+            httpClient: httpClient,
+            applyStorage: applyStorage,
+            telemetryStorage: telemetryStorage,
+            options: options,
+            metadata: metadata,
+            triggerBatch: false
         )
 
-        // When 3 identical apply calls are issued
         await applier.apply(flagName: "flag1", resolveToken: "token1")
         await applier.apply(flagName: "flag1", resolveToken: "token1")
         await applier.apply(flagName: "flag1", resolveToken: "token1")
 
-        // Then http client sends only 1 post requests
         XCTAssertEqual(httpClient.postCallCounter, 1)
     }
 
     func testApply_differentFlags() async {
-        // Given flag applier
         let cacheDataInteractor = CacheDataInteractor(cacheData: .empty())
         let applier = FlagApplierWithRetries(
             httpClient: httpClient,
-            storage: storage,
+            applyStorage: applyStorage,
+            telemetryStorage: telemetryStorage,
             options: options,
             metadata: metadata,
             cacheDataInteractor: cacheDataInteractor,
             triggerBatch: false
         )
 
-        // When 3 apply calls are issued with different flag names
         await applier.apply(flagName: "flag1", resolveToken: "token1")
         await applier.apply(flagName: "flag2", resolveToken: "token1")
         await applier.apply(flagName: "flag3", resolveToken: "token1")
 
         let cacheData = await cacheDataInteractor.cache
 
-        // Then http client sends 3 post requests
         XCTAssertEqual(httpClient.postCallCounter, 3)
         XCTAssertEqual(cacheData.resolveEvents.count, 1)
         XCTAssertEqual(cacheData.resolveEvents[0].events.count, 3)
     }
 
     func testApply_doesNotStoreOnDisk() async throws {
-        // Given flag applier
         let cacheDataInteractor = CacheDataInteractor(cacheData: .empty())
         let applier = FlagApplierWithRetries(
             httpClient: httpClient,
-            storage: storage,
+            applyStorage: applyStorage,
+            telemetryStorage: telemetryStorage,
             options: options,
             metadata: metadata,
             cacheDataInteractor: cacheDataInteractor,
@@ -94,31 +97,27 @@ class FlagApplierWithRetriesTest: XCTestCase {
         networkExpectation.expectedFulfillmentCount = 3
         httpClient.expectation = networkExpectation
 
-        // When 3 apply calls are issued with different flag names
         await applier.apply(flagName: "flag1", resolveToken: "token1")
         await applier.apply(flagName: "flag2", resolveToken: "token1")
         await applier.apply(flagName: "flag3", resolveToken: "token1")
 
         await fulfillment(of: [networkExpectation], timeout: 1.0)
 
-        // Then cache data is not stored on to the disk
-        // But stored in the local cache as sent
         let cacheData = await cacheDataInteractor.cache
         XCTAssertEqual(cacheData.resolveEvents.count, 1)
         XCTAssertEqual(cacheData.resolveEvents[0].events.count, 3)
         XCTAssertTrue(cacheData.resolveEvents[0].events.allSatisfy { $0.status == .sent })
 
-        let storedData = try XCTUnwrap(storage.load(defaultValue: CacheData.empty()))
+        let storedData = try XCTUnwrap(applyStorage.load(defaultValue: CacheData.empty()))
         XCTAssertEqual(storedData.resolveEvents.count, 0)
     }
 
     func testApply_emptyStorage_doesNotTriggerBatchApply() async throws {
-        // Given flag applier with empty storage
-        // When flag applier is initialised
         let task = Task {
             _ = FlagApplierWithRetries(
                 httpClient: httpClient,
-                storage: storage,
+                applyStorage: applyStorage,
+                telemetryStorage: telemetryStorage,
                 options: options,
                 metadata: metadata,
                 triggerBatch: false
@@ -126,12 +125,10 @@ class FlagApplierWithRetriesTest: XCTestCase {
         }
         await task.value
 
-        // Then http client does not send apply flags batch request
         XCTAssertEqual(httpClient.postCallCounter, 0)
     }
 
     func testApply_previoslyStoredData_batchTriggered() async throws {
-        // Given storage that has previously stored data (100 records, same token)
         let prefilledStorage = StorageMock()
         let prefilledCache = try CacheDataUtility.prefilledCacheData(applyEventCount: 100)
         try prefilledStorage.save(data: prefilledCache)
@@ -144,27 +141,24 @@ class FlagApplierWithRetriesTest: XCTestCase {
         storageExpectation.expectedFulfillmentCount = 10
         prefilledStorage.saveExpectation = storageExpectation
 
-        // When flag applier is initialised
         _ = FlagApplierWithRetries(
             httpClient: httpClient,
-            storage: prefilledStorage,
+            applyStorage: prefilledStorage,
+            telemetryStorage: telemetryStorage,
             options: options,
             metadata: metadata
         )
 
         await fulfillment(of: [storageExpectation, expectation], timeout: 5.0)
 
-        // Then http client sends 5 apply flag batch request, containing 20 records each
-        let request = try XCTUnwrap(httpClient.data?.first as? ApplyFlagsRequest)
+        let request = try XCTUnwrap(httpClient.data?.first as? WriteFlagLogsRequest)
         XCTAssertEqual(httpClient.postCallCounter, 5)
-        XCTAssertEqual(request.flags.count, 20)
+        XCTAssertEqual(request.flagAssigned?.first?.flags.count, 20)
     }
 
     func test_previoslyStoredInTransitData_batchTriggered() async throws {
-        // Given storage that has previously stored data (100 records, same token)
         let prefilledStorage = StorageMock()
         var prefilledCache = try CacheDataUtility.prefilledCacheData(applyEventCount: 100)
-        // Set all the events in the cache/storage as in-transit, i.e. `sending`
         prefilledCache.setEventStatus(resolveToken: "token0", status: .sending)
         try prefilledStorage.save(data: prefilledCache)
 
@@ -176,24 +170,22 @@ class FlagApplierWithRetriesTest: XCTestCase {
         storageExpectation.expectedFulfillmentCount = 10
         prefilledStorage.saveExpectation = storageExpectation
 
-        // When flag applier is initialised
         _ = FlagApplierWithRetries(
             httpClient: httpClient,
-            storage: prefilledStorage,
+            applyStorage: prefilledStorage,
+            telemetryStorage: telemetryStorage,
             options: options,
             metadata: metadata
         )
 
         await fulfillment(of: [storageExpectation, expectation], timeout: 5.0)
 
-        // Then http client sends 5 apply flag batch request, containing 20 records each
-        let request = try XCTUnwrap(httpClient.data?.first as? ApplyFlagsRequest)
+        let request = try XCTUnwrap(httpClient.data?.first as? WriteFlagLogsRequest)
         XCTAssertEqual(httpClient.postCallCounter, 5)
-        XCTAssertEqual(request.flags.count, 20)
+        XCTAssertEqual(request.flagAssigned?.first?.flags.count, 20)
     }
 
     func testApply_previoslyStoredData_partialFailure() async throws {
-        // Given storage that has previously stored data (100 records, same token)
         let partiallyFailingHttpClient = HttpClientMock(testMode: .failFirstChunk)
         let prefilledStorage = StorageMock()
         let prefilledCache = try CacheDataUtility.prefilledCacheData(applyEventCount: 100)
@@ -207,22 +199,20 @@ class FlagApplierWithRetriesTest: XCTestCase {
         storageExpectation.expectedFulfillmentCount = 10
         prefilledStorage.saveExpectation = storageExpectation
 
-        // When flag applier is initialised
         _ = FlagApplierWithRetries(
             httpClient: partiallyFailingHttpClient,
-            storage: prefilledStorage,
+            applyStorage: prefilledStorage,
+            telemetryStorage: telemetryStorage,
             options: options,
             metadata: metadata
         )
 
         await fulfillment(of: [storageExpectation, expectation], timeout: 5.0)
 
-        // Then http client sends 5 apply flags batch request, containing 20 records each
-        let request = try XCTUnwrap(partiallyFailingHttpClient.data?.first as? ApplyFlagsRequest)
+        let request = try XCTUnwrap(partiallyFailingHttpClient.data?.first as? WriteFlagLogsRequest)
         XCTAssertEqual(partiallyFailingHttpClient.postCallCounter, 5)
-        XCTAssertEqual(request.flags.count, 20)
+        XCTAssertEqual(request.flagAssigned?.first?.flags.count, 20)
 
-        // And storage has 20 failed events saved
         let storedData = try prefilledStorage.load(defaultValue: CacheData.empty())
         XCTAssertEqual(storedData.resolveEvents.count, 1)
 
@@ -231,7 +221,6 @@ class FlagApplierWithRetriesTest: XCTestCase {
     }
 
     func testApply_multipleApplyCalls_batchTriggered() async throws {
-        // Given flag applier with http client that is offline
         let httpClient = HttpClientMock(testMode: .offline)
         let networkExpectation = self.expectation(description: "Waiting for batch trigger")
         networkExpectation.expectedFulfillmentCount = 2
@@ -239,38 +228,33 @@ class FlagApplierWithRetriesTest: XCTestCase {
 
         let applier = FlagApplierWithRetries(
             httpClient: httpClient,
-            storage: storage,
+            applyStorage: applyStorage,
+            telemetryStorage: telemetryStorage,
             options: options,
             metadata: metadata,
             triggerBatch: false
         )
 
-        // When first apply call is issued
-        // And http client request fails with .invalidResponse
         await applier.apply(flagName: "flag1", resolveToken: "token1")
 
-        // And second apply call is issued
-        // With test mode .success
         httpClient.testMode = .success
         await applier.apply(flagName: "flag2", resolveToken: "token1")
 
         await fulfillment(of: [networkExpectation], timeout: 1.0)
 
-        // Then 3 post calls are issued (one offline, one batch apply containing 2 reconrds)
         XCTAssertEqual(httpClient.postCallCounter, 2)
         XCTAssertEqual(httpClient.data?.count, 2)
 
-        let request1 = try XCTUnwrap(httpClient.data?[0] as? ApplyFlagsRequest)
-        let request2 = try XCTUnwrap(httpClient.data?[1] as? ApplyFlagsRequest)
-        XCTAssertEqual(request1.flags.count, 1)
-        XCTAssertEqual(request1.flags.first?.flag, "flags/flag1")
-        XCTAssertEqual(request2.flags.count, 2)
-        XCTAssertEqual(request2.flags.first?.flag, "flags/flag1")
-        XCTAssertEqual(request2.flags.last?.flag, "flags/flag2")
+        let request1 = try XCTUnwrap(httpClient.data?[0] as? WriteFlagLogsRequest)
+        let request2 = try XCTUnwrap(httpClient.data?[1] as? WriteFlagLogsRequest)
+        XCTAssertEqual(request1.flagAssigned?.first?.flags.count, 1)
+        XCTAssertEqual(request1.flagAssigned?.first?.flags.first?.flag, "flags/flag1")
+        XCTAssertEqual(request2.flagAssigned?.first?.flags.count, 2)
+        XCTAssertEqual(request2.flagAssigned?.first?.flags.first?.flag, "flags/flag1")
+        XCTAssertEqual(request2.flagAssigned?.first?.flags.last?.flag, "flags/flag2")
     }
 
     func testApply_multipleApplyCalls_sentSet() async throws {
-        // Given flag applier with http client that is offline
         let cacheDataInteractor = CacheDataInteractor(cacheData: .empty())
         let offlineClient = HttpClientMock(testMode: .offline)
         let networkExpectation = self.expectation(description: "Waiting for network call to complete")
@@ -279,28 +263,24 @@ class FlagApplierWithRetriesTest: XCTestCase {
 
         let storageExpectation = self.expectation(description: "Waiting for storage expectation to be completed")
         storageExpectation.expectedFulfillmentCount = 6
-        storage.saveExpectation = storageExpectation
+        applyStorage.saveExpectation = storageExpectation
 
         let applier = FlagApplierWithRetries(
             httpClient: offlineClient,
-            storage: storage,
+            applyStorage: applyStorage,
+            telemetryStorage: telemetryStorage,
             options: options,
             metadata: metadata,
             cacheDataInteractor: cacheDataInteractor,
             triggerBatch: false
         )
 
-        // When first apply call is issued
-        // And http client request fails with .invalidResponse
         await applier.apply(flagName: "flag1", resolveToken: "token1")
 
-        // And second apply call is issued
-        // With test mode .success
         offlineClient.testMode = .success
         await applier.apply(flagName: "flag2", resolveToken: "token1")
         await fulfillment(of: [networkExpectation, storageExpectation], timeout: 1.0)
 
-        // Then both requests are marked as sent in cache data
         let cacheData = await cacheDataInteractor.cache
         let flagEvent1 = cacheData.flagEvent(resolveToken: "token1", name: "flag1")
         let flagEvent2 = cacheData.flagEvent(resolveToken: "token1", name: "flag2")
@@ -310,7 +290,6 @@ class FlagApplierWithRetriesTest: XCTestCase {
     }
 
     func testApply_previoslyStoredData_cleanAfterSending() async throws {
-        // Given storage that has previously stored data (100 records, same token)
         let prefilledStorage = StorageMock()
         let prefilledCache = try CacheDataUtility.prefilledCacheData(applyEventCount: 100)
         try prefilledStorage.save(data: prefilledCache)
@@ -323,26 +302,22 @@ class FlagApplierWithRetriesTest: XCTestCase {
         networkExpectation.expectedFulfillmentCount = 5
         httpClient.expectation = networkExpectation
 
-        // When flag applier is initialised
-        // And apply flags batch request is successful
         _ = FlagApplierWithRetries(
             httpClient: httpClient,
-            storage: prefilledStorage,
+            applyStorage: prefilledStorage,
+            telemetryStorage: telemetryStorage,
             options: options,
             metadata: metadata
         )
 
         await fulfillment(of: [storageExpectation, networkExpectation], timeout: 5.0)
 
-        // Then storage has been cleaned
         let storedData = try prefilledStorage.load(defaultValue: CacheData.empty())
         XCTAssertEqual(httpClient.postCallCounter, 5)
         XCTAssertEqual(storedData.resolveEvents.count, 0)
     }
 
     func testApply_100applyCalls_sameToken() async throws {
-        // Given flag applier set up with offline http client
-        // And storage that has previously stored 100 records with same token
         let networkExpectation = self.expectation(description: "Waiting for networkRequest to be completed")
         networkExpectation.expectedFulfillmentCount = 105
         httpClient.expectation = networkExpectation
@@ -352,65 +327,59 @@ class FlagApplierWithRetriesTest: XCTestCase {
         try prefilledStorage.save(data: prefilledCache)
         let applier = FlagApplierWithRetries(
             httpClient: httpClient,
-            storage: prefilledStorage,
+            applyStorage: prefilledStorage,
+            telemetryStorage: telemetryStorage,
             options: options,
             metadata: metadata,
             triggerBatch: false
         )
 
-        // When 100 apply calls are issued
-        // And all http client requests fails with .invalidResponse
         await hundredApplyCalls(applier: applier, sameToken: true)
         await fulfillment(of: [networkExpectation], timeout: 1.0)
 
-        // Then strored data is empty
         let storedData: CacheData = try XCTUnwrap(prefilledStorage.load(defaultValue: CacheData.empty()))
         XCTAssertEqual(storedData.resolveEvents.count, 0)
     }
 
     func testApply_previoslyStoredData_doesNotCleanAfterSendingFailure() throws {
-        // Given offline http client
-        // And storage that has previosly stored data (100 records, same token)
         let offlineClient = HttpClientMock(testMode: .offline)
         let prefilledStorage = StorageMock()
         let prefilledCache = try CacheDataUtility.prefilledCacheData(applyEventCount: 100)
         try prefilledStorage.save(data: prefilledCache)
 
-        // When flag applier is initialised
-        // And apply flags batch request fails with .invalidResponse
         _ = FlagApplierWithRetries(
             httpClient: offlineClient,
-            storage: prefilledStorage,
+            applyStorage: prefilledStorage,
+            telemetryStorage: telemetryStorage,
             options: options,
             metadata: metadata,
             triggerBatch: false
         )
 
-        // Then storage has not been cleaned and contains all 100 records
         let storedData = try prefilledStorage.load(defaultValue: CacheData.empty())
         XCTAssertEqual(storedData.resolveEvents.count, 1)
         XCTAssertEqual(storedData.resolveEvents[0].events.count, 100)
     }
 
     func testApplyOffline_storesOnDisk() async throws {
-        // Given offline http client and flag applier
         let offlineClient = HttpClientMock(testMode: .offline)
         let applier = FlagApplierWithRetries(
-            httpClient: offlineClient, storage: storage, options: options, metadata: metadata, triggerBatch: false
+            httpClient: offlineClient,
+            applyStorage: applyStorage,
+            telemetryStorage: telemetryStorage,
+            options: options,
+            metadata: metadata,
+            triggerBatch: false
         )
 
-        // When 3 apply calls are issued with different flag names
-        // And http client request fails with .invalidResponse
         await applier.apply(flagName: "flag1", resolveToken: "token1")
         await applier.apply(flagName: "flag2", resolveToken: "token1")
         await applier.apply(flagName: "flag3", resolveToken: "token1")
 
-        // Then 1 resolve event record is written to disk
-        let storedData = try XCTUnwrap(storage.load(defaultValue: CacheData.empty()))
+        let storedData = try XCTUnwrap(applyStorage.load(defaultValue: CacheData.empty()))
         let data = try XCTUnwrap(storedData.resolveEvents.first { $0.resolveToken == "token1" })
         XCTAssertEqual(storedData.resolveEvents.count, 1)
 
-        // And 3 flag event records are written to disk
         XCTAssertEqual(data.events.count, 3)
         let flag1 = data.events.first { $0.name == "flag1" }
         let flag2 = data.events.first { $0.name == "flag2" }
@@ -422,23 +391,23 @@ class FlagApplierWithRetriesTest: XCTestCase {
     }
 
     func testApplyOffline_storesOnDisk_multipleTokens() async throws {
-        // Given offline http client and flag applier
         let offlineClient = HttpClientMock(testMode: .offline)
         let applier = FlagApplierWithRetries(
-            httpClient: offlineClient, storage: storage, options: options, metadata: metadata, triggerBatch: false
+            httpClient: offlineClient,
+            applyStorage: applyStorage,
+            telemetryStorage: telemetryStorage,
+            options: options,
+            metadata: metadata,
+            triggerBatch: false
         )
 
-        // When 3 apply calls are issued with different tokens
-        // And http client request fails with .invalidResponse
         await applier.apply(flagName: "flag1", resolveToken: "token1")
         await applier.apply(flagName: "flag2", resolveToken: "token2")
         await applier.apply(flagName: "flag3", resolveToken: "token3")
 
-        // Then 3 resolve event records are written to disk
-        let storedData = try XCTUnwrap(storage.load(defaultValue: CacheData.empty()))
+        let storedData = try XCTUnwrap(applyStorage.load(defaultValue: CacheData.empty()))
         XCTAssertEqual(storedData.resolveEvents.count, 3)
 
-        // And 1 flag event record is written to each of them
         let token1 = storedData.resolveEvents.first { $0.resolveToken == "token1" }
         let token2 = storedData.resolveEvents.first { $0.resolveToken == "token2" }
         let token3 = storedData.resolveEvents.first { $0.resolveToken == "token3" }
@@ -449,8 +418,6 @@ class FlagApplierWithRetriesTest: XCTestCase {
     }
 
     func testApplyOffline_previoslyStoredData_storesOnDisk() async throws {
-        // Given flag applier set up with offline http client
-        // And storage that has previously stored 1 record
         let offlineClient = HttpClientMock(testMode: .offline)
         let data = CacheData(resolveToken: "token0", flagName: "flag1", applyTime: Date(timeIntervalSince1970: 1000))
         let prefilledStorage = try StorageMock(data: data)
@@ -461,23 +428,20 @@ class FlagApplierWithRetriesTest: XCTestCase {
 
         let applier = FlagApplierWithRetries(
             httpClient: offlineClient,
-            storage: prefilledStorage,
+            applyStorage: prefilledStorage,
+            telemetryStorage: telemetryStorage,
             options: options,
             metadata: metadata,
             triggerBatch: false
         )
 
-        // When new apply call is issued
-        // And http client request fails with .invalidResponse
         await applier.apply(flagName: "flag1", resolveToken: "token1")
 
         await fulfillment(of: [networkExpectation], timeout: 1.0)
 
-        // Then 2 resolve event records are stored on disk
         let storedData: CacheData = try XCTUnwrap(prefilledStorage.load(defaultValue: CacheData.empty()))
         XCTAssertEqual(storedData.resolveEvents.count, 2)
 
-        // And added resolve event does not mutate
         let newResolveEvent = try XCTUnwrap(storedData.resolveEvents.first { $0.resolveToken == "token0" })
         XCTAssertEqual(newResolveEvent.events.count, 1)
         XCTAssertEqual(newResolveEvent.events[0].name, "flag1")
@@ -486,38 +450,28 @@ class FlagApplierWithRetriesTest: XCTestCase {
     }
 
     func testApplyOffline_previoslyStoredData_100records() async throws {
-        // Given flag applier set up with offline http client
-        // And storage that has previously stored 100 records with different tokens
         let offlineClient = HttpClientMock(testMode: .offline)
         let prefilledStorage = StorageMock()
         let prefilledCache = try CacheDataUtility.prefilledCacheData(resolveEventCount: 100)
         try prefilledStorage.save(data: prefilledCache)
         let applier = FlagApplierWithRetries(
             httpClient: offlineClient,
-            storage: prefilledStorage,
+            applyStorage: prefilledStorage,
+            telemetryStorage: telemetryStorage,
             options: options,
             metadata: metadata,
             triggerBatch: false
         )
 
-        // When apply call is issued with another token
-        // And http client request fails with .invalidResponse
         await applier.apply(flagName: "flag1", resolveToken: "token1")
 
-        // Then 100 resolve event records are stored on disk
         let storedData: CacheData = try XCTUnwrap(prefilledStorage.load(defaultValue: CacheData.empty()))
         XCTAssertEqual(storedData.resolveEvents.count, 100)
     }
 
     func testApplyOffline_100applyCalls_sameToken() async throws {
-        // Given flag applier set up with offline http client
-        // And storage that has previously stored 100 records with same token
         let offlineClient = HttpClientMock(testMode: .offline)
         let networkExpectation = self.expectation(description: "Waiting for networkRequest to be completed")
-
-        // Since we don't fail other requests when one request is failing
-        // This setup gives us 800 network calls
-        // Every request is split in 6 to 10 batches (from 101 - 200 apply events)
         networkExpectation.expectedFulfillmentCount = 800
         offlineClient.expectation = networkExpectation
 
@@ -526,22 +480,111 @@ class FlagApplierWithRetriesTest: XCTestCase {
         try prefilledStorage.save(data: prefilledCache)
         let applier = FlagApplierWithRetries(
             httpClient: offlineClient,
-            storage: prefilledStorage,
+            applyStorage: prefilledStorage,
+            telemetryStorage: telemetryStorage,
             options: options,
             metadata: metadata,
             triggerBatch: false
         )
 
-        // When 100 apply calls are issued
-        // And all http client requests fails with .invalidResponse
         await hundredApplyCalls(applier: applier, sameToken: true)
         await fulfillment(of: [networkExpectation], timeout: 1.0)
 
-        // Then 1 resolve event record is stored on disk
-        // And 200 flag event records are stored on disk
         let storedData: CacheData = try XCTUnwrap(prefilledStorage.load(defaultValue: CacheData.empty()))
         XCTAssertEqual(storedData.resolveEvents.count, 1)
         XCTAssertEqual(storedData.resolveEvents[0].events.count, 200)
+    }
+
+    // MARK: WriteFlagLogsRequest wire format
+
+    func testApply_sendsWriteFlagLogsRequest() async throws {
+        let applier = FlagApplierWithRetries(
+            httpClient: httpClient,
+            applyStorage: applyStorage,
+            telemetryStorage: telemetryStorage,
+            options: options,
+            metadata: metadata,
+            triggerBatch: false
+        )
+
+        await applier.apply(flagName: "my-flag", resolveToken: "my-token")
+
+        let request = try XCTUnwrap(httpClient.data?.first as? WriteFlagLogsRequest)
+        let flagAssigned = try XCTUnwrap(request.flagAssigned?.first)
+        XCTAssertEqual(flagAssigned.resolveId, "my-token")
+        XCTAssertEqual(flagAssigned.clientInfo.sdk.id, metadata.name)
+        XCTAssertEqual(flagAssigned.clientInfo.sdk.version, metadata.version)
+        XCTAssertEqual(flagAssigned.flags.count, 1)
+        XCTAssertEqual(flagAssigned.flags.first?.flag, "flags/my-flag")
+
+        XCTAssertNotNil(request.telemetryData)
+        XCTAssertEqual(request.telemetryData?.sdk?.id, metadata.name)
+    }
+
+    // MARK: Telemetry
+
+    func testTelemetry_reportStoresAndSends() async throws {
+        let applier = FlagApplierWithRetries(
+            httpClient: httpClient,
+            applyStorage: applyStorage,
+            telemetryStorage: telemetryStorage,
+            options: options,
+            metadata: metadata,
+            triggerBatch: false
+        )
+
+        await applier.report(
+            flagName: "missing-flag",
+            errorCode: .flagNotFound,
+            errorMessage: "Flag 'missing-flag' not found"
+        )
+
+        // The report triggers a batch that sends telemetry-only request
+        XCTAssertGreaterThanOrEqual(httpClient.postCallCounter, 1)
+    }
+
+    func testTelemetry_reportOffline_persistsToDisk() async throws {
+        let offlineClient = HttpClientMock(testMode: .offline)
+        let applier = FlagApplierWithRetries(
+            httpClient: offlineClient,
+            applyStorage: applyStorage,
+            telemetryStorage: telemetryStorage,
+            options: options,
+            metadata: metadata,
+            triggerBatch: false
+        )
+
+        await applier.report(
+            flagName: "my-flag",
+            errorCode: .typeMismatch(),
+            errorMessage: nil
+        )
+
+        let batch = try telemetryStorage.load(defaultValue: TelemetryBatch.empty())
+        XCTAssertEqual(batch.entries.count, 1)
+        XCTAssertEqual(batch.entries.first?.flagName, "my-flag")
+        XCTAssertEqual(batch.entries.first?.errorCode, "TYPE_MISMATCH")
+    }
+
+    func testTelemetry_multipleReports_noDeduplcation() async throws {
+        let offlineClient = HttpClientMock(testMode: .offline)
+        let telemetryInteractor = TelemetryBatchInteractor(batch: .empty())
+        let applier = FlagApplierWithRetries(
+            httpClient: offlineClient,
+            applyStorage: applyStorage,
+            telemetryStorage: telemetryStorage,
+            options: options,
+            metadata: metadata,
+            telemetryInteractor: telemetryInteractor,
+            triggerBatch: false
+        )
+
+        await applier.report(flagName: "flag1", errorCode: .flagNotFound, errorMessage: nil)
+        await applier.report(flagName: "flag1", errorCode: .flagNotFound, errorMessage: nil)
+        await applier.report(flagName: "flag1", errorCode: .flagNotFound, errorMessage: nil)
+
+        let batch = await telemetryInteractor.batch
+        XCTAssertEqual(batch.entries.count, 3)
     }
 
     private func hundredApplyCalls(applier: FlagApplier, sameToken: Bool = false) async {

--- a/Tests/ConfidenceTests/Helpers/TelemetryProducerMock.swift
+++ b/Tests/ConfidenceTests/Helpers/TelemetryProducerMock.swift
@@ -1,0 +1,20 @@
+import Foundation
+import XCTest
+
+@testable import Confidence
+
+class TelemetryProducerMock: TelemetryProducer {
+    var reportCallCount = 0
+    var reportedErrors: [(flagName: String, errorCode: ErrorCode, errorMessage: String?)] = []
+    var reportExpectation = XCTestExpectation(description: "Telemetry Reported")
+
+    init(expectedReports: Int = 1) {
+        reportExpectation.expectedFulfillmentCount = expectedReports
+    }
+
+    func report(flagName: String, errorCode: ErrorCode, errorMessage: String?) async {
+        reportCallCount += 1
+        reportedErrors.append((flagName: flagName, errorCode: errorCode, errorMessage: errorMessage))
+        reportExpectation.fulfill()
+    }
+}

--- a/Tests/ConfidenceTests/Helpers/TelemetryProducerMock.swift
+++ b/Tests/ConfidenceTests/Helpers/TelemetryProducerMock.swift
@@ -3,10 +3,19 @@ import XCTest
 
 @testable import Confidence
 
+struct ReportedError {
+    let flagName: String
+    let errorCode: ErrorCode
+    let errorMessage: String?
+}
+
 class TelemetryProducerMock: TelemetryProducer {
     var reportCallCount = 0
-    var reportedErrors: [(flagName: String, errorCode: ErrorCode, errorMessage: String?)] = []
+    var reportedErrors: [ReportedError] = []
     var reportExpectation = XCTestExpectation(description: "Telemetry Reported")
+
+    var trackResolveCallCount = 0
+    var trackedReasons: [ResolveReason] = []
 
     init(expectedReports: Int = 1) {
         reportExpectation.expectedFulfillmentCount = expectedReports
@@ -14,7 +23,12 @@ class TelemetryProducerMock: TelemetryProducer {
 
     func report(flagName: String, errorCode: ErrorCode, errorMessage: String?) async {
         reportCallCount += 1
-        reportedErrors.append((flagName: flagName, errorCode: errorCode, errorMessage: errorMessage))
+        reportedErrors.append(ReportedError(flagName: flagName, errorCode: errorCode, errorMessage: errorMessage))
         reportExpectation.fulfill()
+    }
+
+    func trackResolve(reason: ResolveReason) async {
+        trackResolveCallCount += 1
+        trackedReasons.append(reason)
     }
 }

--- a/Tests/ConfidenceTests/Helpers/TelemetryProducerMock.swift
+++ b/Tests/ConfidenceTests/Helpers/TelemetryProducerMock.swift
@@ -16,6 +16,7 @@ class TelemetryProducerMock: TelemetryProducer {
 
     var trackResolveCallCount = 0
     var trackedReasons: [ResolveReason] = []
+    var flushCallCount = 0
 
     init(expectedReports: Int = 1) {
         reportExpectation.expectedFulfillmentCount = expectedReports
@@ -30,5 +31,9 @@ class TelemetryProducerMock: TelemetryProducer {
     func trackResolve(reason: ResolveReason) async {
         trackResolveCallCount += 1
         trackedReasons.append(reason)
+    }
+
+    func flush() async {
+        flushCallCount += 1
     }
 }

--- a/Tests/ConfidenceTests/LocalStorageResolverTest.swift
+++ b/Tests/ConfidenceTests/LocalStorageResolverTest.swift
@@ -40,4 +40,185 @@ class LocalStorageResolverTest: XCTestCase {
         XCTAssertEqual(evaluation.errorCode, .flagNotFound)
         XCTAssertEqual(evaluation.errorMessage, "Flag 'new_flag_name' not found in local cache")
     }
+
+    // MARK: - Telemetry resolve_rate tests
+
+    func testTrackResolve_matchEvaluation() throws {
+        let telemetry = TelemetryProducerMock()
+        let context: ConfidenceStruct = ["key": ConfidenceValue(string: "val")]
+        let resolvedValue = ResolvedValue(
+            value: .init(structure: ["string": .init(string: "Value")]),
+            flag: "flag_name",
+            resolveReason: .match,
+            shouldApply: true
+        )
+        let flagResolution = FlagResolution(context: context, flags: [resolvedValue], resolveToken: "token1")
+
+        let evaluation = flagResolution.evaluate(
+            flagName: "flag_name.string",
+            defaultValue: "default",
+            context: context,
+            telemetryProducer: telemetry
+        )
+
+        XCTAssertEqual(evaluation.reason, .match)
+        let expectation = XCTestExpectation(description: "trackResolve called")
+        Task {
+            try await Task.sleep(nanoseconds: 100_000_000)
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertEqual(telemetry.trackResolveCallCount, 1)
+        XCTAssertEqual(telemetry.trackedReasons, [.match])
+        XCTAssertEqual(telemetry.reportCallCount, 0)
+    }
+
+    func testTrackResolve_staleEvaluation() throws {
+        let telemetry = TelemetryProducerMock()
+        let resolveContext: ConfidenceStruct = ["key": ConfidenceValue(string: "old")]
+        let evalContext: ConfidenceStruct = ["key": ConfidenceValue(string: "new")]
+        let resolvedValue = ResolvedValue(
+            value: .init(structure: ["string": .init(string: "Value")]),
+            flag: "flag_name",
+            resolveReason: .match,
+            shouldApply: true
+        )
+        let flagResolution = FlagResolution(context: resolveContext, flags: [resolvedValue], resolveToken: "token1")
+
+        let evaluation = flagResolution.evaluate(
+            flagName: "flag_name.string",
+            defaultValue: "default",
+            context: evalContext,
+            telemetryProducer: telemetry
+        )
+
+        XCTAssertEqual(evaluation.reason, .stale)
+        let expectation = XCTestExpectation(description: "trackResolve called")
+        Task {
+            try await Task.sleep(nanoseconds: 100_000_000)
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertEqual(telemetry.trackResolveCallCount, 1)
+        XCTAssertEqual(telemetry.trackedReasons, [.stale])
+        XCTAssertEqual(telemetry.reportCallCount, 0)
+    }
+
+    func testTrackResolve_noSegmentMatch() throws {
+        let telemetry = TelemetryProducerMock()
+        let context: ConfidenceStruct = [:]
+        let resolvedValue = ResolvedValue(
+            variant: "control",
+            value: .init(structure: ["string": .init(string: "Value")]),
+            flag: "flag_name",
+            resolveReason: .noSegmentMatch,
+            shouldApply: true
+        )
+        let flagResolution = FlagResolution(context: context, flags: [resolvedValue], resolveToken: "token1")
+
+        let evaluation = flagResolution.evaluate(
+            flagName: "flag_name.string",
+            defaultValue: "default",
+            context: context,
+            telemetryProducer: telemetry
+        )
+
+        XCTAssertEqual(evaluation.reason, .noSegmentMatch)
+        let expectation = XCTestExpectation(description: "trackResolve called")
+        Task {
+            try await Task.sleep(nanoseconds: 100_000_000)
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertEqual(telemetry.trackResolveCallCount, 1)
+        XCTAssertEqual(telemetry.trackedReasons, [.noSegmentMatch])
+    }
+
+    func testTrackResolve_notCalledForFlagNotFound() throws {
+        let telemetry = TelemetryProducerMock()
+        let context: ConfidenceStruct = [:]
+        let resolvedValue = ResolvedValue(
+            value: .init(structure: ["string": .init(string: "Value")]),
+            flag: "flag_name",
+            resolveReason: .match,
+            shouldApply: true
+        )
+        let flagResolution = FlagResolution(context: context, flags: [resolvedValue], resolveToken: "token1")
+
+        let evaluation = flagResolution.evaluate(
+            flagName: "missing_flag.string",
+            defaultValue: "default",
+            context: context,
+            telemetryProducer: telemetry
+        )
+
+        XCTAssertEqual(evaluation.reason, .error)
+        XCTAssertEqual(evaluation.errorCode, .flagNotFound)
+        let expectation = XCTestExpectation(description: "report called")
+        Task {
+            try await Task.sleep(nanoseconds: 100_000_000)
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertEqual(telemetry.trackResolveCallCount, 0)
+        XCTAssertEqual(telemetry.reportCallCount, 1)
+    }
+
+    func testTrackResolve_notCalledWhenShouldApplyFalse() throws {
+        let telemetry = TelemetryProducerMock()
+        let context: ConfidenceStruct = [:]
+        let resolvedValue = ResolvedValue(
+            value: .init(structure: ["string": .init(string: "Value")]),
+            flag: "flag_name",
+            resolveReason: .match,
+            shouldApply: false
+        )
+        let flagResolution = FlagResolution(context: context, flags: [resolvedValue], resolveToken: "token1")
+
+        let evaluation = flagResolution.evaluate(
+            flagName: "flag_name.string",
+            defaultValue: "default",
+            context: context,
+            telemetryProducer: telemetry
+        )
+
+        XCTAssertEqual(evaluation.reason, .match)
+        let expectation = XCTestExpectation(description: "wait for task")
+        Task {
+            try await Task.sleep(nanoseconds: 100_000_000)
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertEqual(telemetry.trackResolveCallCount, 0)
+        XCTAssertEqual(telemetry.reportCallCount, 0)
+    }
+
+    func testTrackResolve_notCalledForBackendError() throws {
+        let telemetry = TelemetryProducerMock()
+        let context: ConfidenceStruct = [:]
+        let resolvedValue = ResolvedValue(
+            value: .init(structure: ["string": .init(string: "Value")]),
+            flag: "flag_name",
+            resolveReason: .targetingKeyError,
+            shouldApply: true
+        )
+        let flagResolution = FlagResolution(context: context, flags: [resolvedValue], resolveToken: "token1")
+
+        let evaluation = flagResolution.evaluate(
+            flagName: "flag_name.string",
+            defaultValue: "default",
+            context: context,
+            telemetryProducer: telemetry
+        )
+
+        XCTAssertEqual(evaluation.errorCode, .invalidContext)
+        let expectation = XCTestExpectation(description: "report called")
+        Task {
+            try await Task.sleep(nanoseconds: 100_000_000)
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertEqual(telemetry.trackResolveCallCount, 0)
+        XCTAssertEqual(telemetry.reportCallCount, 1)
+    }
 }


### PR DESCRIPTION
## Summary

Migrates how flag apply data and telemetry are sent on the wire, adds new telemetry counters, and aligns resolve-rate semantics with other platform SDKs.

### Transport change

Previously, apply data and SDK metadata were sent to `POST /v1/flags:apply`, with credentials in the JSON body:

```json
{
  "flags": [{ "flag": "flags/my-flag", "applyTime": "..." }],
  "sendTime": "...",
  "clientSecret": "...",
  "resolveToken": "...",
  "sdk": { "id": "SDK_ID_SWIFT_CONFIDENCE", "version": "1.4.5" }
}
```

Now, the same data is sent to the standard `ClientWriteFlagLogs` endpoint at `POST /v1/clientFlagLogs:write`, used by other platform SDKs. Authentication moves to an `Authorization: ClientSecret <secret>` HTTP header, and the payload follows proto3 JSON format:

```json
{
  "flagAssigned": [{
    "resolveId": "...",
    "clientInfo": { "sdk": { "id": "SDK_ID_SWIFT_CONFIDENCE", "version": "1.4.5" } },
    "flags": [{ "flag": "flags/my-flag", "applyTime": "..." }]
  }],
  "telemetryData": {
    "sdk": { "id": "SDK_ID_SWIFT_CONFIDENCE", "version": "1.4.5" },
    "resolveRate": [
      { "count": 42, "reason": "RESOLVE_REASON_MATCH" },
      { "count": 1, "reason": "RESOLVE_REASON_NO_SEGMENT_MATCH" }
    ],
    "clientErrorRate": [
      { "count": 2, "errorCode": "FLAG_NOT_FOUND" }
    ]
  }
}
```

### Telemetry counters

Two new aggregate counter fields in `telemetryData`:

- **`resolveRate`** — counts per `ResolveReason`, recorded once per flag per evaluation, deduplicated per resolve token (same mechanism as apply). Only flags the app actually evaluates are counted — flags prefetched but never used are excluded. This aligns with WASM provider semantics.
- **`clientErrorRate`** — counts per client-side `ErrorCode` (flag not found, type mismatch, invalid context, etc.)

Both fields are omitted from the JSON when empty. Counters are drained atomically on send and restored on network failure.

**STALE** evaluations (context changed since last resolve) are counted as `RESOLVE_REASON_STALE` in `resolveRate` rather than as a client error, since they represent a valid resolve outcome.

### Network request strategy

Telemetry is designed to minimize mobile network overhead:

| Trigger | When | What gets sent |
|---|---|---|
| `apply()` → `triggerBatch()` | First evaluation per flag per resolve token | Apply events + accumulated telemetry counters |
| `flush()` after `internalFetch()` | Every fetch (fetchAndActivate / asyncFetch) | Accumulated telemetry counters only |
| `init` → `triggerBatch()` | App startup | Persisted data from previous session |

- **`report()` and `trackResolve()` never trigger network requests** — they only accumulate counters in memory and persist to disk.
- Telemetry piggybacks on existing apply requests when possible.
- After each fetch, a lightweight `flush()` sends accumulated counters (since the SDK just made a resolve network call, one more POST is negligible).
- On app startup, any persisted counters from the previous session are flushed.

### Backwards compatibility

- The old `/v1/flags:apply` endpoint is **no longer called**. This is a full migration to `ClientWriteFlagLogs`.
- The new endpoint already exists and is used by other platform SDKs — no backend changes needed for the core apply flow.
- `resolveRate` and `clientErrorRate` follow proto3 JSON conventions — unknown fields are ignored by the backend, so older versions safely discard them.

## Test plan

- [x] All unit tests pass
- [ ] Verify backend accepts the new `WriteFlagLogsRequest` format
- [ ] Verify counter data appears in telemetry pipeline