### PR TITLE
ci: declare minimum permissions on workflow files

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,6 +8,9 @@ on:
     branches:
       - 'main'
 
+permissions:
+  contents: read
+
 jobs:
   API-diff:
     strategy:

--- a/.github/workflows/lint-pr.yaml
+++ b/.github/workflows/lint-pr.yaml
@@ -7,6 +7,10 @@ on:
       - edited
       - synchronize
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   main:
     name: Validate PR title

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -3,6 +3,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+  pull-requests: write
+
 name: Run Release Please
 jobs:
   release-please:


### PR DESCRIPTION
## Summary
- Adds explicit workflow-level `permissions:` blocks to harden `GITHUB_TOKEN` scope
- Standard CI workflows get `contents: read`
- Lint-pr workflow (running on `pull_request_target`) gets `contents: read` + `pull-requests: write`
- Release-please workflow gets `contents: write` + `pull-requests: write`

Motivated by CVE-2025-30066 — pinning permissions caps token authority if a third-party action is compromised.