### PR TITLE
ci: explicitly pass test flag name in integration tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,12 +38,13 @@ jobs:
       - name: Build and Run Integration Tests
         env:
           CLIENT_TOKEN: ${{ secrets.CONFIDENCE_CLIENT_TOKEN }}
+          TEST_FLAG_NAME: swift-test-flag
         run: |
           if [ -z "$CLIENT_TOKEN" ]; then
             echo "Secret CONFIDENCE_CLIENT_TOKEN is not available. Skipping integration tests."
             exit 0
           fi
-          scripts/run_integration_tests.sh $CLIENT_TOKEN
+          scripts/run_integration_tests.sh $CLIENT_TOKEN $TEST_FLAG_NAME
 
   DemoApp:
     runs-on: macOS-latest


### PR DESCRIPTION
## Summary
- Pass `TEST_FLAG_NAME` explicitly in CI workflow instead of relying on the `TEST_FLAG_NAME` repo secret
- Verifies integration tests work against the new Confidence workspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)