### PR TITLE
feat: integrate OpenFeature Events and Track with Confidence provider

### DIFF
--- a/Sources/ConfidenceProvider/ConfidenceFeatureProvider.swift
+++ b/Sources/ConfidenceProvider/ConfidenceFeatureProvider.swift
@@ -46,13 +46,20 @@ public class ConfidenceFeatureProvider: FeatureProvider {
     public func initialize(initialContext: OpenFeature.EvaluationContext?) async throws {
         let context = ConfidenceTypeMapper.from(ctx: initialContext ?? ImmutableContext(attributes: [:]))
         confidence.putContextLocal(context: context)
-        if initializationStrategy == .activateAndFetchAsync {
-            try confidence.activate()
-            Task {
-                await confidence.asyncFetch()
+        do {
+            if initializationStrategy == .activateAndFetchAsync {
+                try confidence.activate()
+                Task {
+                    await confidence.asyncFetch()
+                }
+            } else {
+                try await confidence.fetchAndActivate()
             }
-        } else {
-            try await confidence.fetchAndActivate()
+            eventHandler.send(ProviderEvent.ready())
+        } catch {
+            eventHandler.send(
+                ProviderEvent.error(ProviderEventDetails(message: error.localizedDescription)))
+            throw error
         }
     }
 
@@ -67,6 +74,8 @@ public class ConfidenceFeatureProvider: FeatureProvider {
         oldContext: OpenFeature.EvaluationContext?,
         newContext: OpenFeature.EvaluationContext
     ) async {
+        eventHandler.send(ProviderEvent.reconciling())
+
         let newContextMap = newContext.asMap()
         let newKeys = Set(Array(newContextMap.keys))
         let targetingKey = newContext.getTargetingKey()
@@ -79,6 +88,8 @@ public class ConfidenceFeatureProvider: FeatureProvider {
         await confidence.putContextAndWait(
             context: ConfidenceTypeMapper.from(contextMap: newContextMap, targetingKey: targetingKey),
             removedKeys: removedKeys)
+
+        eventHandler.send(ProviderEvent.contextChanged())
     }
 
     public func getBooleanEvaluation(key: String, defaultValue: Bool, context: EvaluationContext?) throws
@@ -128,6 +139,24 @@ public class ConfidenceFeatureProvider: FeatureProvider {
 
     public func observe() -> AnyPublisher<OpenFeature.ProviderEvent?, Never> {
         return eventHandler.observe()
+    }
+
+    public func track(
+        key: String,
+        context: (any EvaluationContext)?,
+        details: (any TrackingEventDetails)?
+    ) throws {
+        var data: ConfidenceStruct = [:]
+        if let details = details {
+            let map = details.asMap()
+            for (mapKey, value) in map {
+                data[mapKey] = ConfidenceTypeMapper.from(value: value)
+            }
+            if let numericValue = details.getValue() {
+                data["value"] = ConfidenceValue(double: numericValue)
+            }
+        }
+        try confidence.track(eventName: key, data: data)
     }
 
     private func withLock(callback: @escaping (ConfidenceFeatureProvider) -> Void) {

--- a/Tests/ConfidenceProviderTests/ConfidenceProviderTest.swift
+++ b/Tests/ConfidenceProviderTests/ConfidenceProviderTest.swift
@@ -787,6 +787,170 @@ class ConfidenceProviderTest: XCTestCase {
         }
     }
 
+    func testTrackForwardsToConfidence() async throws {
+        let storage = StorageMock()
+        let resolvedValue = createResolvedValue(
+            structure: ["size": .init(integer: 3)]
+        )
+        let client = createFakeClient(resolvedValues: [resolvedValue])
+
+        let confidence = Confidence.Builder(clientSecret: "test")
+            .withContext(initialContext: ["targeting_key": .init(string: "user1")])
+            .withFlagResolverClient(flagResolver: client)
+            .withStorage(storage: storage)
+            .build()
+
+        let cancellable = await setupProviderAndWaitForReady(confidence: confidence)
+        cancellable.cancel()
+
+        let provider = ConfidenceFeatureProvider(confidence: confidence)
+
+        let details = ImmutableTrackingEventDetails(
+            attributes: ["plan": .string("premium"), "amount": .integer(42)]
+        )
+        XCTAssertNoThrow(try provider.track(key: "purchase", context: nil, details: details))
+    }
+
+    func testTrackWithValueForwardsToConfidence() async throws {
+        let storage = StorageMock()
+        let resolvedValue = createResolvedValue(
+            structure: ["size": .init(integer: 3)]
+        )
+        let client = createFakeClient(resolvedValues: [resolvedValue])
+
+        let confidence = Confidence.Builder(clientSecret: "test")
+            .withContext(initialContext: ["targeting_key": .init(string: "user1")])
+            .withFlagResolverClient(flagResolver: client)
+            .withStorage(storage: storage)
+            .build()
+
+        let cancellable = await setupProviderAndWaitForReady(confidence: confidence)
+        cancellable.cancel()
+
+        let provider = ConfidenceFeatureProvider(confidence: confidence)
+
+        let details = ImmutableTrackingEventDetails(
+            value: 99.9,
+            structure: ImmutableStructure(attributes: ["item": .string("widget")])
+        )
+        XCTAssertNoThrow(try provider.track(key: "conversion", context: nil, details: details))
+    }
+
+    func testTrackWithNoDetailsForwardsToConfidence() async throws {
+        let storage = StorageMock()
+        let resolvedValue = createResolvedValue(
+            structure: ["size": .init(integer: 3)]
+        )
+        let client = createFakeClient(resolvedValues: [resolvedValue])
+
+        let confidence = Confidence.Builder(clientSecret: "test")
+            .withContext(initialContext: ["targeting_key": .init(string: "user1")])
+            .withFlagResolverClient(flagResolver: client)
+            .withStorage(storage: storage)
+            .build()
+
+        let cancellable = await setupProviderAndWaitForReady(confidence: confidence)
+        cancellable.cancel()
+
+        let provider = ConfidenceFeatureProvider(confidence: confidence)
+
+        XCTAssertNoThrow(try provider.track(key: "page_view", context: nil, details: nil))
+    }
+
+    func testProviderEmitsReadyEvent() async throws {
+        let readyExpectation = XCTestExpectation(description: "Ready event emitted")
+        let storage = StorageMock()
+        let resolvedValue = createResolvedValue(
+            structure: ["size": .init(integer: 3)]
+        )
+        let client = createFakeClient(resolvedValues: [resolvedValue])
+
+        let confidence = Confidence.Builder(clientSecret: "test")
+            .withContext(initialContext: ["targeting_key": .init(string: "user1")])
+            .withFlagResolverClient(flagResolver: client)
+            .withStorage(storage: storage)
+            .build()
+
+        let provider = ConfidenceFeatureProvider(confidence: confidence)
+
+        let cancellable = provider.observe().sink { event in
+            if let event = event, event == .ready() {
+                readyExpectation.fulfill()
+            }
+        }
+
+        try await provider.initialize(initialContext: ImmutableContext(targetingKey: "user1"))
+        await fulfillment(of: [readyExpectation], timeout: 5.0)
+        cancellable.cancel()
+    }
+
+    func testProviderEmitsErrorEvent() async throws {
+        let errorExpectation = XCTestExpectation(description: "Error event emitted")
+        let storage = createFakeStorage(shouldThrowOnLoad: true)
+
+        let confidence = Confidence.Builder(clientSecret: "test")
+            .withContext(initialContext: ["targeting_key": .init(string: "user1")])
+            .withStorage(storage: storage)
+            .build()
+
+        let provider = ConfidenceFeatureProvider(
+            confidence: confidence,
+            initializationStrategy: .activateAndFetchAsync
+        )
+
+        let cancellable = provider.observe().sink { event in
+            if let event = event, case .error = event {
+                errorExpectation.fulfill()
+            }
+        }
+
+        do {
+            try await provider.initialize(initialContext: ImmutableContext(targetingKey: "user1"))
+        } catch {
+            // Expected error
+        }
+        await fulfillment(of: [errorExpectation], timeout: 5.0)
+        cancellable.cancel()
+    }
+
+    func testProviderEmitsReconcilingAndContextChangedEvents() async throws {
+        let reconcilingExpectation = XCTestExpectation(description: "Reconciling event emitted")
+        let contextChangedExpectation = XCTestExpectation(description: "ContextChanged event emitted")
+        let storage = StorageMock()
+        let resolvedValue = createResolvedValue(
+            structure: ["size": .init(integer: 3)]
+        )
+        let client = createFakeClient(resolvedValues: [resolvedValue])
+
+        let confidence = Confidence.Builder(clientSecret: "test")
+            .withContext(initialContext: ["targeting_key": .init(string: "user1")])
+            .withFlagResolverClient(flagResolver: client)
+            .withStorage(storage: storage)
+            .build()
+
+        let provider = ConfidenceFeatureProvider(confidence: confidence)
+        try await provider.initialize(initialContext: ImmutableContext(targetingKey: "user1"))
+
+        let cancellable = provider.observe().sink { event in
+            if let event = event {
+                if case .reconciling = event {
+                    reconcilingExpectation.fulfill()
+                }
+                if case .contextChanged = event {
+                    contextChangedExpectation.fulfill()
+                }
+            }
+        }
+
+        await provider.onContextSet(
+            oldContext: ImmutableContext(targetingKey: "user1"),
+            newContext: ImmutableContext(targetingKey: "user2")
+        )
+
+        await fulfillment(of: [reconcilingExpectation, contextChangedExpectation], timeout: 5.0)
+        cancellable.cancel()
+    }
+
     func testProviderResolveAllListTypes() async throws {
         let context = ImmutableContext(targetingKey: "user2")
         let storage = StorageMock()


### PR DESCRIPTION
## Summary
- **Events**: The `ConfidenceFeatureProvider` now emits OpenFeature lifecycle events via `EventHandler.send()`:
  - `.ready()` on successful initialization
  - `.error()` with details when initialization fails
  - `.reconciling()` when context is being updated
  - `.contextChanged()` after context update completes
- **Track**: Implements `track(key:context:details:)` to forward OpenFeature tracking calls to Confidence's `track(eventName:data:)`, converting `TrackingEventDetails` attributes and numeric value to `ConfidenceStruct`

## Test plan
- [x] Tests for track forwarding with attributes, numeric value, and no details
- [x] Tests for `.ready` event emission on successful init
- [x] Tests for `.error` event emission on failed init
- [x] Tests for `.reconciling` and `.contextChanged` events on context set
- [x] All 40 provider tests pass (6 new + 34 existing)
- [x] Full test suite: only pre-existing integration test failures (missing API token)

🤖 Generated with [Claude Code](https://claude.com/claude-code)