### PR TITLE
feat: OpenFeature track and event delivery reliability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,30 +1,5 @@
 # Changelog
 
-## Unreleased
-
-### 🐛 Bug Fixes
-
-* Log per-event rejection reason and message when the events API returns HTTP 200 with batch errors.
-* Synchronize `EventSenderEngine` shutdown state to avoid a data race on concurrent `emit()` calls.
-* Drain the event write queue before the final shutdown upload so in-flight events are persisted.
-
-### ✨ New Features
-
-* OpenFeature `track()` support in `ConfidenceFeatureProvider`, merging stored client evaluation context with the Confidence session at provider track time.
-* Optional timed event flush via `Confidence.Builder.withEventFlushInterval(_:)`.
-* Startup and shutdown event flush in `EventSenderEngine`.
-* Public `ConfidenceFeatureProvider.shutdown()` drains and shuts down the event sender via `confidence.stop()` (OpenFeature provider lifecycle).
-
-### 🔄 Refactoring
-
-* Event payload merger: an explicit `"context"` key in event data overrides the evaluation context instead of throwing `invalidContextInMessage`.
-
-### ⚠️ Breaking Changes
-
-* Pin OpenFeature Swift SDK to version 0.6.0 (`ProviderStatusTracker`, `Future`-based `initialize`/`onContextSet`, non-optional `observe()` events). Minimum iOS deployment target raised to 15.0.
-* OpenFeature track mapping omits the `"value"` field when no numeric tracking value is set (previously sent `"value": null`).
-* Passing `"context"` in event data no longer throws; it overrides the evaluation context for that event.
-
 ## [1.5.0](https://github.com/spotify/confidence-sdk-swift/compare/1.4.5...1.5.0) (2026-03-23)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## Unreleased
+
+### 🐛 Bug Fixes
+
+* Log per-event rejection reason and message when the events API returns HTTP 200 with batch errors.
+* Synchronize `EventSenderEngine` shutdown state to avoid a data race on concurrent `emit()` calls.
+* Drain the event write queue before the final shutdown upload so in-flight events are persisted.
+
+### ✨ New Features
+
+* OpenFeature `track()` support in `ConfidenceFeatureProvider`, merging stored client evaluation context with the Confidence session at provider track time.
+* Optional timed event flush via `Confidence.Builder.withEventFlushInterval(_:)`.
+* Startup and shutdown event flush in `EventSenderEngine`.
+* Public `ConfidenceFeatureProvider.shutdown()` drains and shuts down the event sender via `confidence.stop()` (OpenFeature provider lifecycle).
+
+### 🔄 Refactoring
+
+* Event payload merger: an explicit `"context"` key in event data overrides the evaluation context instead of throwing `invalidContextInMessage`.
+
+### ⚠️ Breaking Changes
+
+* Pin OpenFeature Swift SDK to version 0.6.0 (`ProviderStatusTracker`, `Future`-based `initialize`/`onContextSet`, non-optional `observe()` events). Minimum iOS deployment target raised to 15.0.
+* OpenFeature track mapping omits the `"value"` field when no numeric tracking value is set (previously sent `"value": null`).
+* Passing `"context"` in event data no longer throws; it overrides the evaluation context for that event.
+
 ## [1.5.0](https://github.com/spotify/confidence-sdk-swift/compare/1.4.5...1.5.0) (2026-03-23)
 
 

--- a/Sources/Confidence/Confidence.swift
+++ b/Sources/Confidence/Confidence.swift
@@ -407,7 +407,7 @@ extension Confidence {
         internal var region: ConfidenceRegion = .global
         internal var initialContext: ConfidenceStruct = [:]
         internal var timeout: Double = 10
-        internal var eventFlushInterval: TimeInterval?
+        internal var eventFlushInterval = EventSenderEngineImpl.defaultFlushInterval
 
         // Injectable for testing
         internal var flagApplier: FlagApplier?
@@ -476,8 +476,9 @@ extension Confidence {
         }
 
         /**
-        Set a periodic flush interval for tracked events, in seconds. Disabled by default.
-        When set, pending events are uploaded on this interval even if the batch size threshold has not been reached.
+        Set the periodic flush interval for tracked events, in seconds. Defaults to 60 seconds.
+        Pending events are uploaded on this interval even if the batch size threshold has not been reached.
+        Set a non-positive interval to disable periodic flushing.
         */
         public func withEventFlushInterval(_ interval: TimeInterval) -> Builder {
             self.eventFlushInterval = interval

--- a/Sources/Confidence/Confidence.swift
+++ b/Sources/Confidence/Confidence.swift
@@ -328,14 +328,10 @@ public class Confidence: ConfidenceEventSender {
     }
 
     public func track(eventName: String, data: ConfidenceStruct) throws {
-        try track(eventName: eventName, data: data, eventContext: getContext())
-    }
-
-    public func track(eventName: String, data: ConfidenceStruct, eventContext: ConfidenceStruct) throws {
         try eventSenderEngine.emit(
             eventName: eventName,
             data: data,
-            context: eventContext
+            context: getContext()
         )
     }
 

--- a/Sources/Confidence/Confidence.swift
+++ b/Sources/Confidence/Confidence.swift
@@ -328,15 +328,27 @@ public class Confidence: ConfidenceEventSender {
     }
 
     public func track(eventName: String, data: ConfidenceStruct) throws {
+        try track(eventName: eventName, data: data, eventContext: getContext())
+    }
+
+    public func track(eventName: String, data: ConfidenceStruct, eventContext: ConfidenceStruct) throws {
         try eventSenderEngine.emit(
             eventName: eventName,
             data: data,
-            context: getContext()
+            context: eventContext
         )
     }
 
     public func flush() {
         eventSenderEngine.flush()
+    }
+
+    /**
+    Flush pending tracked events and shut down the event sender engine.
+    Call when the SDK is no longer needed, for example on app termination.
+    */
+    public func stop() {
+        eventSenderEngine.shutdown()
     }
 }
 
@@ -395,6 +407,7 @@ extension Confidence {
         internal var region: ConfidenceRegion = .global
         internal var initialContext: ConfidenceStruct = [:]
         internal var timeout: Double = 10
+        internal var eventFlushInterval: TimeInterval?
 
         // Injectable for testing
         internal var flagApplier: FlagApplier?
@@ -463,6 +476,15 @@ extension Confidence {
         }
 
         /**
+        Set a periodic flush interval for tracked events, in seconds. Disabled by default.
+        When set, pending events are uploaded on this interval even if the batch size threshold has not been reached.
+        */
+        public func withEventFlushInterval(_ interval: TimeInterval) -> Builder {
+            self.eventFlushInterval = interval
+            return self
+        }
+
+        /**
         Build the Confidence instance.
         */
         public func build() -> Confidence {
@@ -506,7 +528,8 @@ extension Confidence {
                 clientSecret: clientSecret,
                 uploader: uploader,
                 storage: eventStorage,
-                debugLogger: debugLogger
+                debugLogger: debugLogger,
+                flushInterval: eventFlushInterval
             )
             return Confidence(
                 clientSecret: clientSecret,

--- a/Sources/Confidence/ConfidenceValue.swift
+++ b/Sources/Confidence/ConfidenceValue.swift
@@ -68,7 +68,7 @@ public class ConfidenceValue: Equatable, Codable, CustomStringConvertible {
         self.value = .list(stringList.map { .string($0) })
     }
 
-    internal init(list: [ConfidenceValue]) {
+    public init(list: [ConfidenceValue]) {
         self.value = .list(list.map { $0.value })
     }
 

--- a/Sources/Confidence/EventSenderEngine.swift
+++ b/Sources/Confidence/EventSenderEngine.swift
@@ -95,7 +95,7 @@ final class EventSenderEngineImpl: EventSenderEngine {
 
         uploadReqChannel.sink { [weak self] _ in
             guard let self = self else { return }
-            await self.upload()
+            await self.sealAndUpload()
         }
         .store(in: &cancellables)
 
@@ -103,40 +103,55 @@ final class EventSenderEngineImpl: EventSenderEngine {
             startFlushIntervalTimer(flushInterval)
         }
 
+        do {
+            try storage.startNewBatch()
+        } catch {
+        }
         Task {
-            await self.upload()
+            await self.uploadReadyBatches()
         }
     }
 
-    func upload() async {
+    func sealAndUpload() async {
         await withSemaphore { [weak self] in
             guard let self = self else { return }
             do {
                 try self.storage.startNewBatch()
-                let ids = try storage.batchReadyIds()
-                if ids.isEmpty {
-                    return
-                }
-                for id in ids {
-                    let events: [NetworkEvent] = try self.storage.eventsFrom(id: id)
-                        .compactMap { event in
-                            return NetworkEvent(
-                                eventDefinition: event.name,
-                                payload: NetworkStruct(fields: TypeMapper.convert(structure: event.payload).fields),
-                                eventTime: Date.backport.toISOString(date: event.eventTime))
-                        }
-                    var shouldCleanup = false
-                    if events.isEmpty {
-                        shouldCleanup = true
-                    } else {
-                        shouldCleanup = try await self.uploader.upload(events: events)
-                    }
-
-                    if shouldCleanup {
-                        try storage.remove(id: id)
-                    }
-                }
+                try await self.uploadReadyBatchesWithoutLock()
             } catch {
+            }
+        }
+    }
+
+    private func uploadReadyBatches() async {
+        await withSemaphore { [weak self] in
+            guard let self = self else { return }
+            do {
+                try await self.uploadReadyBatchesWithoutLock()
+            } catch {
+            }
+        }
+    }
+
+    private func uploadReadyBatchesWithoutLock() async throws {
+        let ids = try storage.batchReadyIds()
+        for id in ids {
+            let events: [NetworkEvent] = try storage.eventsFrom(id: id)
+                .compactMap { event in
+                    NetworkEvent(
+                        eventDefinition: event.name,
+                        payload: NetworkStruct(fields: TypeMapper.convert(structure: event.payload).fields),
+                        eventTime: Date.backport.toISOString(date: event.eventTime)
+                    )
+                }
+            let shouldCleanup: Bool
+            if events.isEmpty {
+                shouldCleanup = true
+            } else {
+                shouldCleanup = try await uploader.upload(events: events)
+            }
+            if shouldCleanup {
+                try storage.remove(id: id)
             }
         }
     }
@@ -212,7 +227,7 @@ final class EventSenderEngineImpl: EventSenderEngine {
     private func waitForFinalUpload() {
         let shutdownComplete = DispatchSemaphore(value: 0)
         Task {
-            await self.upload()
+            await self.sealAndUpload()
             shutdownComplete.signal()
         }
         if shutdownComplete.wait(timeout: .now() + shutdownTimeout) == .timedOut {

--- a/Sources/Confidence/EventSenderEngine.swift
+++ b/Sources/Confidence/EventSenderEngine.swift
@@ -30,12 +30,16 @@ final class EventSenderEngineImpl: EventSenderEngine {
     private let semaphore = DispatchSemaphore(value: 1)
     private let writeQueue: DispatchQueue
     private let debugLogger: DebugLogger?
+    private var flushIntervalTimer: DispatchSourceTimer?
+    private let shutdownLock = NSLock()
+    private var isShutdown = false
 
     convenience init(
         clientSecret: String,
         uploader: ConfidenceClient,
         storage: EventStorage,
-        debugLogger: DebugLogger?
+        debugLogger: DebugLogger?,
+        flushInterval: TimeInterval? = nil
     ) {
         self.init(
             clientSecret: clientSecret,
@@ -43,7 +47,8 @@ final class EventSenderEngineImpl: EventSenderEngine {
             storage: storage,
             flushPolicies: [SizeFlushPolicy(batchSize: 10)],
             writeQueue: DispatchQueue(label: "ConfidenceWriteQueue"),
-            debugLogger: debugLogger
+            debugLogger: debugLogger,
+            flushInterval: flushInterval
         )
     }
 
@@ -53,7 +58,8 @@ final class EventSenderEngineImpl: EventSenderEngine {
         storage: EventStorage,
         flushPolicies: [FlushPolicy],
         writeQueue: DispatchQueue,
-        debugLogger: DebugLogger?
+        debugLogger: DebugLogger?,
+        flushInterval: TimeInterval? = nil
     ) {
         self.uploader = uploader
         self.clientSecret = clientSecret
@@ -84,16 +90,26 @@ final class EventSenderEngineImpl: EventSenderEngine {
 
         uploadReqChannel.sink { [weak self] _ in
             guard let self = self else { return }
-            await self.upload()
+            await self.upload(sealCurrentBatch: true)
         }
         .store(in: &cancellables)
+
+        if let flushInterval, flushInterval > 0 {
+            startFlushIntervalTimer(flushInterval)
+        }
+
+        Task {
+            await self.upload(sealCurrentBatch: false)
+        }
     }
 
-    func upload() async {
+    func upload(sealCurrentBatch: Bool = true) async {
         await withSemaphore { [weak self] in
             guard let self = self else { return }
             do {
-                try self.storage.startNewBatch()
+                if sealCurrentBatch {
+                    try self.storage.startNewBatch()
+                }
                 let ids = try storage.batchReadyIds()
                 if ids.isEmpty {
                     return
@@ -138,6 +154,16 @@ final class EventSenderEngineImpl: EventSenderEngine {
         data: ConfidenceStruct,
         context: ConfidenceStruct
     ) throws {
+        shutdownLock.lock()
+        let rejected = isShutdown
+        shutdownLock.unlock()
+        guard !rejected else {
+            debugLogger?.logMessage(
+                message: "Event '\(eventName)' dropped: engine is shut down",
+                isWarning: true
+            )
+            return
+        }
         let event = ConfidenceEvent(
             name: eventName,
             payload: try payloadMerger.merge(context: context, data: data),
@@ -152,10 +178,51 @@ final class EventSenderEngineImpl: EventSenderEngine {
     }
 
     func shutdown() {
+        shutdownLock.lock()
+        isShutdown = true
+        shutdownLock.unlock()
+
+        flushIntervalTimer?.cancel()
+        flushIntervalTimer = nil
+
+        flush()
+        writeQueue.sync { }
+
+        waitForFinalUpload()
+
         for cancellable in cancellables {
             cancellable.cancel()
         }
         cancellables.removeAll()
+    }
+
+    deinit {
+        flushIntervalTimer?.cancel()
+    }
+
+    private func waitForFinalUpload() {
+        let shutdownComplete = DispatchSemaphore(value: 0)
+        Task {
+            await self.upload(sealCurrentBatch: true)
+            shutdownComplete.signal()
+        }
+        if Thread.isMainThread {
+            DispatchQueue.global(qos: .userInitiated).sync {
+                shutdownComplete.wait()
+            }
+        } else {
+            shutdownComplete.wait()
+        }
+    }
+
+    private func startFlushIntervalTimer(_ interval: TimeInterval) {
+        let timer = DispatchSource.makeTimerSource(queue: writeQueue)
+        timer.schedule(deadline: .now() + interval, repeating: interval)
+        timer.setEventHandler { [weak self] in
+            self?.flush()
+        }
+        timer.resume()
+        flushIntervalTimer = timer
     }
 }
 

--- a/Sources/Confidence/EventSenderEngine.swift
+++ b/Sources/Confidence/EventSenderEngine.swift
@@ -18,7 +18,9 @@ protocol EventSenderEngine {
 }
 
 final class EventSenderEngineImpl: EventSenderEngine {
+    static let defaultFlushInterval: TimeInterval = 60
     private static let sendSignalName: String = "FLUSH"
+    private static let defaultShutdownTimeout: TimeInterval = 10
     private let storage: any EventStorage
     private let writeReqChannel = PassthroughSubject<ConfidenceEvent, Never>()
     private let uploadReqChannel = PassthroughSubject<String, Never>()
@@ -30,6 +32,7 @@ final class EventSenderEngineImpl: EventSenderEngine {
     private let semaphore = DispatchSemaphore(value: 1)
     private let writeQueue: DispatchQueue
     private let debugLogger: DebugLogger?
+    private let shutdownTimeout: TimeInterval
     private var flushIntervalTimer: DispatchSourceTimer?
     private let shutdownLock = NSLock()
     private var isShutdown = false
@@ -39,7 +42,7 @@ final class EventSenderEngineImpl: EventSenderEngine {
         uploader: ConfidenceClient,
         storage: EventStorage,
         debugLogger: DebugLogger?,
-        flushInterval: TimeInterval? = nil
+        flushInterval: TimeInterval = EventSenderEngineImpl.defaultFlushInterval
     ) {
         self.init(
             clientSecret: clientSecret,
@@ -59,7 +62,8 @@ final class EventSenderEngineImpl: EventSenderEngine {
         flushPolicies: [FlushPolicy],
         writeQueue: DispatchQueue,
         debugLogger: DebugLogger?,
-        flushInterval: TimeInterval? = nil
+        flushInterval: TimeInterval = EventSenderEngineImpl.defaultFlushInterval,
+        shutdownTimeout: TimeInterval = EventSenderEngineImpl.defaultShutdownTimeout
     ) {
         self.uploader = uploader
         self.clientSecret = clientSecret
@@ -67,6 +71,7 @@ final class EventSenderEngineImpl: EventSenderEngine {
         self.flushPolicies = flushPolicies + [ManualFlushPolicy()]
         self.writeQueue = writeQueue
         self.debugLogger = debugLogger
+        self.shutdownTimeout = shutdownTimeout
 
         writeReqChannel
             .receive(on: self.writeQueue)
@@ -94,10 +99,14 @@ final class EventSenderEngineImpl: EventSenderEngine {
         }
         .store(in: &cancellables)
 
-        if let flushInterval, flushInterval > 0 {
+        if flushInterval > 0 {
             startFlushIntervalTimer(flushInterval)
         }
 
+        do {
+            try storage.startNewBatch()
+        } catch {
+        }
         Task {
             await self.upload(sealCurrentBatch: false)
         }
@@ -154,21 +163,23 @@ final class EventSenderEngineImpl: EventSenderEngine {
         data: ConfidenceStruct,
         context: ConfidenceStruct
     ) throws {
+        let event = ConfidenceEvent(
+            name: eventName,
+            payload: try payloadMerger.merge(context: context, data: data),
+            eventTime: Date.backport.now)
+
         shutdownLock.lock()
-        let rejected = isShutdown
-        shutdownLock.unlock()
-        guard !rejected else {
+        guard !isShutdown else {
+            shutdownLock.unlock()
             debugLogger?.logMessage(
                 message: "Event '\(eventName)' dropped: engine is shut down",
                 isWarning: true
             )
             return
         }
-        let event = ConfidenceEvent(
-            name: eventName,
-            payload: try payloadMerger.merge(context: context, data: data),
-            eventTime: Date.backport.now)
         writeReqChannel.send(event)
+        shutdownLock.unlock()
+
         debugLogger?.logEvent(action: "Emitting event", event: event)
     }
 
@@ -179,6 +190,10 @@ final class EventSenderEngineImpl: EventSenderEngine {
 
     func shutdown() {
         shutdownLock.lock()
+        guard !isShutdown else {
+            shutdownLock.unlock()
+            return
+        }
         isShutdown = true
         shutdownLock.unlock()
 
@@ -206,12 +221,11 @@ final class EventSenderEngineImpl: EventSenderEngine {
             await self.upload(sealCurrentBatch: true)
             shutdownComplete.signal()
         }
-        if Thread.isMainThread {
-            DispatchQueue.global(qos: .userInitiated).sync {
-                shutdownComplete.wait()
-            }
-        } else {
-            shutdownComplete.wait()
+        if shutdownComplete.wait(timeout: .now() + shutdownTimeout) == .timedOut {
+            debugLogger?.logMessage(
+                message: "Timed out waiting for final event upload; pending events remain stored for retry",
+                isWarning: true
+            )
         }
     }
 

--- a/Sources/Confidence/EventSenderEngine.swift
+++ b/Sources/Confidence/EventSenderEngine.swift
@@ -95,7 +95,7 @@ final class EventSenderEngineImpl: EventSenderEngine {
 
         uploadReqChannel.sink { [weak self] _ in
             guard let self = self else { return }
-            await self.upload(sealCurrentBatch: true)
+            await self.upload()
         }
         .store(in: &cancellables)
 
@@ -103,22 +103,16 @@ final class EventSenderEngineImpl: EventSenderEngine {
             startFlushIntervalTimer(flushInterval)
         }
 
-        do {
-            try storage.startNewBatch()
-        } catch {
-        }
         Task {
-            await self.upload(sealCurrentBatch: false)
+            await self.upload()
         }
     }
 
-    func upload(sealCurrentBatch: Bool = true) async {
+    func upload() async {
         await withSemaphore { [weak self] in
             guard let self = self else { return }
             do {
-                if sealCurrentBatch {
-                    try self.storage.startNewBatch()
-                }
+                try self.storage.startNewBatch()
                 let ids = try storage.batchReadyIds()
                 if ids.isEmpty {
                     return
@@ -218,7 +212,7 @@ final class EventSenderEngineImpl: EventSenderEngine {
     private func waitForFinalUpload() {
         let shutdownComplete = DispatchSemaphore(value: 0)
         Task {
-            await self.upload(sealCurrentBatch: true)
+            await self.upload()
             shutdownComplete.signal()
         }
         if shutdownComplete.wait(timeout: .now() + shutdownTimeout) == .timedOut {

--- a/Sources/Confidence/EventStorage.swift
+++ b/Sources/Confidence/EventStorage.swift
@@ -35,6 +35,10 @@ internal class EventStorageImpl: EventStorage {
             guard let currentFileName = self.currentFileUrl else {
                 return
             }
+            let attributes = try FileManager.default.attributesOfItem(atPath: currentFileName.path)
+            guard let fileSize = attributes[.size] as? NSNumber, fileSize.intValue > 0 else {
+                return
+            }
             try currentFileHandle?.close()
             try FileManager.default.moveItem(
                 at: currentFileName,

--- a/Sources/Confidence/EventStorageInMemory.swift
+++ b/Sources/Confidence/EventStorageInMemory.swift
@@ -4,6 +4,9 @@ final class EventStorageInMemory: EventStorage {
     private var events: [ConfidenceEvent] = []
     private var batches: [String: [ConfidenceEvent]] = [:]
     func startNewBatch() throws {
+        guard !events.isEmpty else {
+            return
+        }
         batches[("\(batches.count)")] = events
         events.removeAll()
     }

--- a/Sources/Confidence/PayloadMerger.swift
+++ b/Sources/Confidence/PayloadMerger.swift
@@ -6,11 +6,13 @@ internal protocol PayloadMerger {
 
 internal struct PayloadMergerImpl: PayloadMerger {
     func merge(context: ConfidenceStruct, data: ConfidenceStruct) throws -> ConfidenceStruct {
-        guard data["context"] == nil else {
-            throw ConfidenceError.invalidContextInMessage
-        }
         var map: ConfidenceStruct = data
-        map["context"] = ConfidenceValue.init(structure: context)
+        if let contextFromData = data["context"] {
+            // An explicit "context" entry in event data overrides the evaluation context for this event.
+            map["context"] = contextFromData
+        } else {
+            map["context"] = ConfidenceValue.init(structure: context)
+        }
         return map
     }
 }

--- a/Sources/Confidence/README.md
+++ b/Sources/Confidence/README.md
@@ -202,8 +202,7 @@ try confidence.track(eventName: "MyEvent", data: ["field": ConfidenceValue(strin
 
 The SDK takes care of storing events in case of offline and retries in case of transient failures.
 
-Note that the data struct can't contain the key `context`, as that is reserved for entries set via `putContext` (see below):
-violating this rule will cause the track function to throw an error.
+Note that an explicit `"context"` entry in event data overrides the evaluation context attached to that event. Evaluation context is otherwise appended automatically from context set via `putContext` (see below):
 
 To set context data to be appended to all tracked events, here is an example:
 ```swift

--- a/Sources/Confidence/RemoteConfidenceClient.swift
+++ b/Sources/Confidence/RemoteConfidenceClient.swift
@@ -51,50 +51,65 @@ public class RemoteConfidenceClient: ConfidenceClient {
             )
             switch result {
             case .success(let successData):
-                let status = successData.response.statusCode
-                let indecesWithError = successData.decodedData?.errors.map { error in
-                    error.index
-                } ?? []
-                let successEventNames = events.enumerated()
-                    // Filter only events in batch that have no error reported from backend
-                    .filter { index, _ in
-                        return !(indecesWithError.contains(index))
-                    }
-                    .map { _, event in
-                        event.eventDefinition
-                    }
-                switch status {
-                case 200:
-                    // clean up in case of success
-                    debugLogger?.logMessage(
-                        message: "Event upload: HTTP status 200. Events: \(successEventNames.joined(separator: ","))",
-                        isWarning: false
-                    )
-                    return true
-                case 429:
-                    // we shouldn't clean up for rate limiting
-                    debugLogger?.logMessage(
-                        message: "Event upload: HTTP status 429",
-                        isWarning: true
-                    )
-                    return false
-                case 400...499:
-                    // if batch couldn't be processed, we should clean it up
-                    debugLogger?.logMessage(
-                        message: "Event upload: couldn't process batch",
-                        isWarning: true
-                    )
-                    return true
-                default:
-                    debugLogger?.logMessage(
-                        message: "Event upload error. Status code \(status)",
-                        isWarning: true
-                    )
-                    return false
-                }
+                return handleSuccess(successData: successData, events: events)
             case .failure(let errorData):
                 throw handleError(error: errorData)
             }
+        }
+    }
+
+    private func handleSuccess(
+        successData: HttpClientResponse<PublishEventResponse>,
+        events: [NetworkEvent]
+    ) -> Bool {
+        let status = successData.response.statusCode
+        let indicesWithError = successData.decodedData?.errors.map { error in
+            error.index
+        } ?? []
+        let successEventNames = events.enumerated()
+            .filter { index, _ in
+                return !(indicesWithError.contains(index))
+            }
+            .map { _, event in
+                event.eventDefinition
+            }
+        switch status {
+        case 200:
+            if let errors = successData.decodedData?.errors, !errors.isEmpty {
+                for error in errors {
+                    let eventName = events.indices.contains(error.index)
+                        ? events[error.index].eventDefinition
+                        : "index-\(error.index)"
+                    debugLogger?.logMessage(
+                        message: "Event upload rejected: \(eventName) "
+                            + "reason=\(error.reason.rawValue) message=\(error.message)",
+                        isWarning: true
+                    )
+                }
+            }
+            debugLogger?.logMessage(
+                message: "Event upload: HTTP status 200. Events: \(successEventNames.joined(separator: ","))",
+                isWarning: false
+            )
+            return true
+        case 429:
+            debugLogger?.logMessage(
+                message: "Event upload: HTTP status 429",
+                isWarning: true
+            )
+            return false
+        case 400...499:
+            debugLogger?.logMessage(
+                message: "Event upload: couldn't process batch",
+                isWarning: true
+            )
+            return true
+        default:
+            debugLogger?.logMessage(
+                message: "Event upload error. Status code \(status)",
+                isWarning: true
+            )
+            return false
         }
     }
 

--- a/Sources/ConfidenceProvider/ConfidenceFeatureProvider.swift
+++ b/Sources/ConfidenceProvider/ConfidenceFeatureProvider.swift
@@ -158,16 +158,17 @@ public class ConfidenceFeatureProvider: FeatureProvider {
     }
 
     public func track(key: String, context: (any EvaluationContext)?, details: (any TrackingEventDetails)?) throws {
-        // OpenFeature static-context clients pass the stored evaluation context here (not per-call overrides).
-        let eventContext = ConfidenceTypeMapper.mergeEventContext(
-            sessionContext: confidence.getContext(),
-            openFeatureContext: ConfidenceTypeMapper.from(ctx: context)
-        )
-        try confidence.track(
-            eventName: key,
-            data: ConfidenceTypeMapper.from(trackingDetails: details),
-            eventContext: eventContext
-        )
+        var data = ConfidenceTypeMapper.from(trackingDetails: details)
+        let openFeatureContext = ConfidenceTypeMapper.from(ctx: context)
+        if data["context"] == nil && !openFeatureContext.isEmpty {
+            data["context"] = ConfidenceValue(
+                structure: ConfidenceTypeMapper.mergeEventContext(
+                    sessionContext: confidence.getContext(),
+                    openFeatureContext: openFeatureContext
+                )
+            )
+        }
+        try confidence.track(eventName: key, data: data)
     }
 
     public func observe() -> AnyPublisher<OpenFeature.ProviderEvent, Never> {

--- a/Sources/ConfidenceProvider/ConfidenceFeatureProvider.swift
+++ b/Sources/ConfidenceProvider/ConfidenceFeatureProvider.swift
@@ -74,6 +74,7 @@ public class ConfidenceFeatureProvider: FeatureProvider {
     }
 
     public func shutdown() {
+        confidence.stop()
         for cancellable in cancellables {
             cancellable.cancel()
         }
@@ -154,6 +155,19 @@ public class ConfidenceFeatureProvider: FeatureProvider {
         default:
             throw OpenFeatureError.generalError(message: "Unexpected default value type: must be Dictionary or Array")
         }
+    }
+
+    public func track(key: String, context: (any EvaluationContext)?, details: (any TrackingEventDetails)?) throws {
+        // OpenFeature static-context clients pass the stored evaluation context here (not per-call overrides).
+        let eventContext = ConfidenceTypeMapper.mergeEventContext(
+            sessionContext: confidence.getContext(),
+            openFeatureContext: ConfidenceTypeMapper.from(ctx: context)
+        )
+        try confidence.track(
+            eventName: key,
+            data: ConfidenceTypeMapper.from(trackingDetails: details),
+            eventContext: eventContext
+        )
     }
 
     public func observe() -> AnyPublisher<OpenFeature.ProviderEvent, Never> {

--- a/Sources/ConfidenceProvider/ConfidenceTypeMapper.swift
+++ b/Sources/ConfidenceProvider/ConfidenceTypeMapper.swift
@@ -50,9 +50,30 @@ public enum ConfidenceTypeMapper {
             data["value"] = ConfidenceValue(double: numericValue)
         }
         for (attributeKey, attributeValue) in trackingDetails.asMap() {
-            data[attributeKey] = convertValue(attributeValue)
+            data[attributeKey] = convertTrackingValue(attributeValue)
         }
         return data
+    }
+
+    static private func convertTrackingValue(_ value: Value) -> ConfidenceValue {
+        switch value {
+        case .boolean(let value):
+            return ConfidenceValue(boolean: value)
+        case .string(let value):
+            return ConfidenceValue(string: value)
+        case .integer(let value):
+            return ConfidenceValue(integer: Int(value))
+        case .double(let value):
+            return ConfidenceValue(double: value)
+        case .date(let value):
+            return ConfidenceValue(timestamp: value)
+        case .list(let values):
+            return ConfidenceValue(list: values.map(convertTrackingValue))
+        case .structure(let values):
+            return ConfidenceValue(structure: values.mapValues(convertTrackingValue))
+        case .null:
+            return ConfidenceValue(null: ())
+        }
     }
 
     // swiftlint:disable:next cyclomatic_complexity

--- a/Sources/ConfidenceProvider/ConfidenceTypeMapper.swift
+++ b/Sources/ConfidenceProvider/ConfidenceTypeMapper.swift
@@ -25,6 +25,7 @@ public enum ConfidenceTypeMapper {
         return ofCtxMap.compactMapValues(convertValue)
     }
 
+    /// OpenFeature evaluation context takes precedence over Confidence session context on key conflicts.
     static func mergeEventContext(
         sessionContext: ConfidenceStruct,
         openFeatureContext: ConfidenceStruct

--- a/Sources/ConfidenceProvider/ConfidenceTypeMapper.swift
+++ b/Sources/ConfidenceProvider/ConfidenceTypeMapper.swift
@@ -25,6 +25,36 @@ public enum ConfidenceTypeMapper {
         return ofCtxMap.compactMapValues(convertValue)
     }
 
+    static func mergeEventContext(
+        sessionContext: ConfidenceStruct,
+        openFeatureContext: ConfidenceStruct
+    ) -> ConfidenceStruct {
+        guard !openFeatureContext.isEmpty else {
+            return sessionContext
+        }
+        var merged = sessionContext
+        for (key, value) in openFeatureContext {
+            merged[key] = value
+        }
+        return merged
+    }
+
+    static func from(trackingDetails: (any TrackingEventDetails)?) -> ConfidenceStruct {
+        guard let trackingDetails else {
+            return [:]
+        }
+        // OpenFeature exposes an optional numeric value separately from structure attributes; map it
+        // to a "value" field when present and let an explicit attribute named "value" take precedence.
+        var data: ConfidenceStruct = [:]
+        if let numericValue = trackingDetails.getValue() {
+            data["value"] = ConfidenceValue(double: numericValue)
+        }
+        for (attributeKey, attributeValue) in trackingDetails.asMap() {
+            data[attributeKey] = convertValue(attributeValue)
+        }
+        return data
+    }
+
     // swiftlint:disable:next cyclomatic_complexity
     static private func convertValue(_ value: Value) -> ConfidenceValue {
         switch value {

--- a/Tests/ConfidenceProviderTests/ConfidenceProviderTest.swift
+++ b/Tests/ConfidenceProviderTests/ConfidenceProviderTest.swift
@@ -963,7 +963,7 @@ class ConfidenceProviderTest: XCTestCase {
         XCTAssertEqual(event.data["value"], ConfidenceValue(string: "override"))
     }
 
-    func testTrackMergesStoredEvaluationContextWithSessionContext() throws {
+    func testTrackPrefersOpenFeatureContextOverSessionContext() throws {
         let engine = EventSenderEngineSpy()
         let confidence = makeConfidence(
             eventSenderEngine: engine,
@@ -981,12 +981,13 @@ class ConfidenceProviderTest: XCTestCase {
         try provider.track(key: "Checkout", context: storedContext, details: nil)
 
         let event = try XCTUnwrap(engine.emittedEvents.first)
-        XCTAssertEqual(event.context["plan"], ConfidenceValue(string: "premium"))
-        XCTAssertEqual(event.context["country"], ConfidenceValue(string: "SE"))
-        XCTAssertEqual(event.context["targeting_key"], ConfidenceValue(string: "user-1"))
+        let context = try XCTUnwrap(event.payload["context"]?.asStructure())
+        XCTAssertEqual(context["plan"], ConfidenceValue(string: "premium"))
+        XCTAssertEqual(context["country"], ConfidenceValue(string: "SE"))
+        XCTAssertEqual(context["targeting_key"], ConfidenceValue(string: "user-1"))
     }
 
-    func testTrackContextAttributeOverridesMergedEvaluationContext() throws {
+    func testTrackContextAttributeOverridesEvaluationContext() throws {
         let engine = EventSenderEngineSpy()
         let confidence = makeConfidence(
             eventSenderEngine: engine,

--- a/Tests/ConfidenceProviderTests/ConfidenceProviderTest.swift
+++ b/Tests/ConfidenceProviderTests/ConfidenceProviderTest.swift
@@ -900,6 +900,162 @@ class ConfidenceProviderTest: XCTestCase {
         XCTAssertNil(evaluation.errorCode)
         XCTAssertNil(evaluation.errorMessage)
     }
+
+    // MARK: - Tracking
+
+    func testTrackForwardsEventToConfidence() throws {
+        let engine = EventSenderEngineSpy()
+        let provider = ConfidenceFeatureProvider(confidence: makeConfidence(eventSenderEngine: engine))
+
+        let details = ImmutableTrackingEventDetails(
+            value: 499.99,
+            structure: ImmutableStructure(attributes: [
+                "numberOfItems": .integer(4),
+                "timeInCheckout": .string("PT3M20S")
+            ])
+        )
+
+        try provider.track(key: "Checkout", context: nil, details: details)
+
+        XCTAssertEqual(engine.emittedEvents.count, 1)
+        let event = try XCTUnwrap(engine.emittedEvents.first)
+        XCTAssertEqual(event.name, "Checkout")
+        XCTAssertEqual(event.data["value"], ConfidenceValue(double: 499.99))
+        XCTAssertEqual(event.data["numberOfItems"], ConfidenceValue(integer: 4))
+        XCTAssertEqual(event.data["timeInCheckout"], ConfidenceValue(string: "PT3M20S"))
+    }
+
+    func testTrackWithoutDetailsSendsEmptyData() throws {
+        let engine = EventSenderEngineSpy()
+        let provider = ConfidenceFeatureProvider(confidence: makeConfidence(eventSenderEngine: engine))
+
+        try provider.track(key: "PageView", context: nil, details: nil)
+
+        XCTAssertEqual(engine.emittedEvents.count, 1)
+        let event = try XCTUnwrap(engine.emittedEvents.first)
+        XCTAssertEqual(event.name, "PageView")
+        XCTAssertTrue(event.data.isEmpty)
+    }
+
+    func testTrackWithoutNumericValueOmitsValueKey() throws {
+        let engine = EventSenderEngineSpy()
+        let provider = ConfidenceFeatureProvider(confidence: makeConfidence(eventSenderEngine: engine))
+
+        let details = ImmutableTrackingEventDetails(attributes: ["item": .string("shoes")])
+        try provider.track(key: "AddToCart", context: nil, details: details)
+
+        let event = try XCTUnwrap(engine.emittedEvents.first)
+        XCTAssertNil(event.data["value"])
+        XCTAssertEqual(event.data["item"], ConfidenceValue(string: "shoes"))
+    }
+
+    func testTrackValueAttributeOverridesNumericValue() throws {
+        let engine = EventSenderEngineSpy()
+        let provider = ConfidenceFeatureProvider(confidence: makeConfidence(eventSenderEngine: engine))
+
+        let details = ImmutableTrackingEventDetails(
+            value: 99.77,
+            structure: ImmutableStructure(attributes: ["value": .string("override")])
+        )
+        try provider.track(key: "Checkout", context: nil, details: details)
+
+        let event = try XCTUnwrap(engine.emittedEvents.first)
+        XCTAssertEqual(event.data["value"], ConfidenceValue(string: "override"))
+    }
+
+    func testTrackMergesStoredEvaluationContextWithSessionContext() throws {
+        let engine = EventSenderEngineSpy()
+        let confidence = makeConfidence(
+            eventSenderEngine: engine,
+            initialContext: ["plan": ConfidenceValue(string: "free")]
+        )
+        let provider = ConfidenceFeatureProvider(confidence: confidence)
+
+        let storedContext = ImmutableContext(
+            targetingKey: "user-1",
+            structure: ImmutableStructure(attributes: [
+                "plan": .string("premium"),
+                "country": .string("SE")
+            ])
+        )
+        try provider.track(key: "Checkout", context: storedContext, details: nil)
+
+        let event = try XCTUnwrap(engine.emittedEvents.first)
+        XCTAssertEqual(event.context["plan"], ConfidenceValue(string: "premium"))
+        XCTAssertEqual(event.context["country"], ConfidenceValue(string: "SE"))
+        XCTAssertEqual(event.context["targeting_key"], ConfidenceValue(string: "user-1"))
+    }
+
+    func testTrackContextAttributeOverridesMergedEvaluationContext() throws {
+        let engine = EventSenderEngineSpy()
+        let confidence = makeConfidence(
+            eventSenderEngine: engine,
+            initialContext: ["plan": ConfidenceValue(string: "free")]
+        )
+        let provider = ConfidenceFeatureProvider(confidence: confidence)
+
+        let details = ImmutableTrackingEventDetails(attributes: [
+            "context": .structure(["source": .string("details")])
+        ])
+        try provider.track(
+            key: "Checkout",
+            context: ImmutableContext(attributes: ["plan": .string("premium")]),
+            details: details
+        )
+
+        let event = try XCTUnwrap(engine.emittedEvents.first)
+        XCTAssertEqual(
+            event.payload["context"],
+            ConfidenceValue(structure: ["source": ConfidenceValue(string: "details")])
+        )
+    }
+
+    private func makeConfidence(
+        eventSenderEngine: EventSenderEngine,
+        initialContext: ConfidenceStruct = [:]
+    ) -> Confidence {
+        Confidence(
+            clientSecret: "test",
+            region: .global,
+            eventSenderEngine: eventSenderEngine,
+            flagApplier: NoOpFlagApplier(),
+            remoteFlagResolver: createFakeClient(resolvedValues: []),
+            storage: StorageMock(),
+            telemetry: Telemetry(sdkId: Confidence.sdkId, library: .confidence, libraryVersion: "test"),
+            context: initialContext,
+            debugLogger: nil
+        )
+    }
+}
+
+private struct EmittedEvent {
+    let name: String
+    let data: ConfidenceStruct
+    let context: ConfidenceStruct
+    let payload: ConfidenceStruct
+}
+
+private class EventSenderEngineSpy: EventSenderEngine {
+    var emittedEvents: [EmittedEvent] = []
+
+    func emit(eventName: String, data: ConfidenceStruct, context: ConfidenceStruct) throws {
+        emittedEvents.append(
+            EmittedEvent(
+                name: eventName,
+                data: data,
+                context: context,
+                payload: try PayloadMergerImpl().merge(context: context, data: data)
+            )
+        )
+    }
+
+    func shutdown() {}
+
+    func flush() {}
+}
+
+private class NoOpFlagApplier: FlagApplier {
+    func apply(flagName: String, resolveToken: String) async {}
 }
 
 private class StorageMock: Storage {

--- a/Tests/ConfidenceProviderTests/ConfidenceTypeMapperTest.swift
+++ b/Tests/ConfidenceProviderTests/ConfidenceTypeMapperTest.swift
@@ -182,4 +182,39 @@ class ValueConverterTest: XCTestCase {
             ConfidenceValue(structure: ["flag": ConfidenceValue(boolean: true)])
         )
     }
+
+    func testTrackingDetailsPreservesRecursiveLists() {
+        let details = ImmutableTrackingEventDetails(
+            structure: ImmutableStructure(attributes: [
+                "empty": .list([]),
+                "structures": .list([
+                    .structure(["name": .string("first")]),
+                    .structure(["name": .string("second")])
+                ]),
+                "nested": .list([
+                    .list([.integer(1), .string("two")])
+                ])
+            ])
+        )
+
+        let data = ConfidenceTypeMapper.from(trackingDetails: details)
+
+        XCTAssertEqual(data["empty"], ConfidenceValue(list: []))
+        XCTAssertEqual(
+            data["structures"],
+            ConfidenceValue(list: [
+                ConfidenceValue(structure: ["name": ConfidenceValue(string: "first")]),
+                ConfidenceValue(structure: ["name": ConfidenceValue(string: "second")])
+            ])
+        )
+        XCTAssertEqual(
+            data["nested"],
+            ConfidenceValue(list: [
+                ConfidenceValue(list: [
+                    ConfidenceValue(integer: 1),
+                    ConfidenceValue(string: "two")
+                ])
+            ])
+        )
+    }
 }

--- a/Tests/ConfidenceProviderTests/ConfidenceTypeMapperTest.swift
+++ b/Tests/ConfidenceProviderTests/ConfidenceTypeMapperTest.swift
@@ -146,7 +146,7 @@ class ValueConverterTest: XCTestCase {
         XCTAssertEqual(confidenceValue, expected)
     }
 
-    func testMergeEventContextUsesOpenFeatureValuesOnConflict() {
+    func testMergeEventContextGivesOpenFeaturePrecedenceOnConflict() {
         let merged = ConfidenceTypeMapper.mergeEventContext(
             sessionContext: ["plan": ConfidenceValue(string: "free"), "visitor_id": ConfidenceValue(string: "v1")],
             openFeatureContext: ["plan": ConfidenceValue(string: "premium"), "country": ConfidenceValue(string: "SE")]

--- a/Tests/ConfidenceProviderTests/ConfidenceTypeMapperTest.swift
+++ b/Tests/ConfidenceProviderTests/ConfidenceTypeMapperTest.swift
@@ -145,4 +145,41 @@ class ValueConverterTest: XCTestCase {
         ]))
         XCTAssertEqual(confidenceValue, expected)
     }
+
+    func testMergeEventContextUsesOpenFeatureValuesOnConflict() {
+        let merged = ConfidenceTypeMapper.mergeEventContext(
+            sessionContext: ["plan": ConfidenceValue(string: "free"), "visitor_id": ConfidenceValue(string: "v1")],
+            openFeatureContext: ["plan": ConfidenceValue(string: "premium"), "country": ConfidenceValue(string: "SE")]
+        )
+        XCTAssertEqual(merged["plan"], ConfidenceValue(string: "premium"))
+        XCTAssertEqual(merged["visitor_id"], ConfidenceValue(string: "v1"))
+        XCTAssertEqual(merged["country"], ConfidenceValue(string: "SE"))
+    }
+
+    func testTrackingDetailsValueAttributeOverridesNumericValue() {
+        let details = ImmutableTrackingEventDetails(
+            value: 99.77,
+            structure: ImmutableStructure(attributes: ["value": .string("override")])
+        )
+        let data = ConfidenceTypeMapper.from(trackingDetails: details)
+        XCTAssertEqual(data["value"], ConfidenceValue(string: "override"))
+    }
+
+    func testTrackingDetailsMapsStructureAttributes() {
+        let details = ImmutableTrackingEventDetails(
+            structure: ImmutableStructure(attributes: [
+                "key": .string("value"),
+                "count": .integer(4),
+                "meta": .structure(["flag": .boolean(true)])
+            ])
+        )
+        let data = ConfidenceTypeMapper.from(trackingDetails: details)
+        XCTAssertNil(data["value"])
+        XCTAssertEqual(data["key"], ConfidenceValue(string: "value"))
+        XCTAssertEqual(data["count"], ConfidenceValue(integer: 4))
+        XCTAssertEqual(
+            data["meta"],
+            ConfidenceValue(structure: ["flag": ConfidenceValue(boolean: true)])
+        )
+    }
 }

--- a/Tests/ConfidenceProviderTests/ProviderTrackIntegrationTest.swift
+++ b/Tests/ConfidenceProviderTests/ProviderTrackIntegrationTest.swift
@@ -1,0 +1,128 @@
+import Combine
+import ConfidenceProvider
+import Foundation
+import OpenFeature
+import XCTest
+
+@testable import Confidence
+
+final class ProviderTrackIntegrationTest: XCTestCase {
+    override func setUp() async throws {
+        try await super.setUp()
+        OpenFeatureAPI.shared.clearProvider()
+        try cleanEventStorageFolder()
+    }
+
+    override func tearDown() async throws {
+        await OpenFeatureAPI.shared.clearProviderAndWait()
+        try await super.tearDown()
+    }
+
+    func testOpenFeatureTrackPersistsEventToDisk() async throws {
+        let targetingKey = UUID().uuidString
+        let initialContext = ImmutableContext(
+            targetingKey: targetingKey,
+            structure: ImmutableStructure(attributes: [
+                "user": .structure(["country": .string("SE")])
+            ])
+        )
+
+        let confidence = Confidence.Builder(clientSecret: "test-client-secret")
+            .withFlagResolverClient(flagResolver: EmptyResolveClient())
+            .build()
+
+        let provider = ConfidenceFeatureProvider(
+            confidence: confidence,
+            initializationStrategy: .activateAndFetchAsync
+        )
+
+        let cancellable = provider.observe().sink { _ in }
+
+        await OpenFeatureAPI.shared.setProviderAndWait(provider: provider, initialContext: initialContext)
+        XCTAssertEqual(OpenFeatureAPI.shared.getProviderStatus(), .ready)
+
+        let folderURL = try EventStorageImpl.getFolderURL()
+        let inFlightFiles = try inFlightBatchFiles(in: folderURL)
+        XCTAssertEqual(inFlightFiles.count, 1)
+        XCTAssertTrue(try readInFlightEvents(from: folderURL).isEmpty)
+
+        OpenFeatureAPI.shared.getClient().track(
+            key: "MyEventName",
+            details: ImmutableTrackingEventDetails(
+                value: 33.0,
+                structure: ImmutableStructure(attributes: ["key": .string("value")])
+            )
+        )
+
+        let events = try await waitForInFlightEvents(count: 1)
+        let event = try XCTUnwrap(events.first)
+        XCTAssertEqual(event.name, "MyEventName")
+        XCTAssertEqual(event.payload["value"], ConfidenceValue(double: 33.0))
+        XCTAssertEqual(event.payload["key"], ConfidenceValue(string: "value"))
+
+        let context = try XCTUnwrap(event.payload["context"]?.asStructure())
+        XCTAssertEqual(context["targeting_key"], ConfidenceValue(string: targetingKey))
+        XCTAssertNotNil(context["visitor_id"]?.asString())
+        XCTAssertEqual(
+            context["user"]?.asStructure()?["country"],
+            ConfidenceValue(string: "SE")
+        )
+
+        cancellable.cancel()
+    }
+
+    private func cleanEventStorageFolder() throws {
+        let folderURL = try EventStorageImpl.getFolderURL()
+        if FileManager.default.fileExists(atPath: folderURL.path) {
+            try FileManager.default.removeItem(at: folderURL)
+        }
+    }
+
+    private func inFlightBatchFiles(in folderURL: URL) throws -> [URL] {
+        try FileManager.default.contentsOfDirectory(at: folderURL, includingPropertiesForKeys: nil)
+            .filter { $0.pathExtension != "READY" }
+    }
+
+    private func readInFlightEvents(from folderURL: URL) throws -> [ConfidenceEvent] {
+        guard let currentFile = try inFlightBatchFiles(in: folderURL).first else {
+            return []
+        }
+
+        let data = try Data(contentsOf: currentFile)
+        guard let dataString = String(data: data, encoding: .utf8) else {
+            return []
+        }
+
+        let decoder = JSONDecoder()
+        return try dataString.components(separatedBy: "\n")
+            .filter { !$0.isEmpty }
+            .map { line in
+                guard let lineData = line.data(using: .utf8) else {
+                    throw ConfidenceError.internalError(message: "Invalid event line encoding")
+                }
+                return try decoder.decode(ConfidenceEvent.self, from: lineData)
+            }
+    }
+
+    private func waitForInFlightEvents(count: Int, timeout: TimeInterval = 5.0) async throws -> [ConfidenceEvent] {
+        let folderURL = try EventStorageImpl.getFolderURL()
+        let deadline = Date().addingTimeInterval(timeout)
+
+        while Date() < deadline {
+            let events = try readInFlightEvents(from: folderURL)
+            if events.count == count {
+                return events
+            }
+            try await Task.sleep(nanoseconds: 50_000_000)
+        }
+
+        XCTFail("Timed out waiting for \(count) in-flight event(s)")
+        return []
+    }
+}
+
+private struct EmptyResolveClient: ConfidenceResolveClient {
+    func resolve(ctx: ConfidenceStruct) async throws -> ResolvesResult {
+        .init(resolvedValues: [], resolveToken: "token")
+    }
+}

--- a/Tests/ConfidenceTests/ConfidenceTest.swift
+++ b/Tests/ConfidenceTests/ConfidenceTest.swift
@@ -867,15 +867,32 @@ class ConfidenceTest: XCTestCase {
         XCTAssertEqual(flagApplier.applyCallCount, 0)
     }
 
-    func testInvalidContextInMessage() async throws {
-        let confidence = Confidence.Builder(clientSecret: "test")
-            .build()
-
-        XCTAssertThrowsError(
-            try confidence.track(eventName: "test", data: ["context": ConfidenceValue(string: "test")])
-        ) { error in
-            XCTAssertEqual(error as? ConfidenceError, ConfidenceError.invalidContextInMessage)
+    func testContextInDataOverridesEvaluationContext() throws {
+        let engine = EventSenderEngineSpy()
+        class FakeClient: ConfidenceResolveClient {
+            func resolve(ctx: ConfidenceStruct) async throws -> ResolvesResult {
+                .init(resolvedValues: [], resolveToken: "token")
+            }
         }
+        let confidence = Confidence(
+            clientSecret: "test",
+            region: .global,
+            eventSenderEngine: engine,
+            flagApplier: flagApplier,
+            remoteFlagResolver: FakeClient(),
+            storage: storage,
+            telemetry: Telemetry(sdkId: Confidence.sdkId, library: .confidence, libraryVersion: "test"),
+            debugLogger: nil
+        )
+
+        try confidence.track(
+            eventName: "test",
+            data: ["context": ConfidenceValue(string: "override")],
+            eventContext: ["session": ConfidenceValue(string: "ignored")]
+        )
+
+        XCTAssertEqual(engine.emittedPayloads.count, 1)
+        XCTAssertEqual(engine.emittedPayloads[0]["context"], ConfidenceValue(string: "override"))
     }
 
     func testTypeMismatch() async throws {
@@ -1427,6 +1444,18 @@ class ConfidenceTest: XCTestCase {
         XCTAssertNil(evaluation.errorMessage)
         XCTAssertNil(evaluation.errorCode)
     }
+}
+
+private final class EventSenderEngineSpy: EventSenderEngine {
+    var emittedPayloads: [ConfidenceStruct] = []
+
+    func emit(eventName: String, data: ConfidenceStruct, context: ConfidenceStruct) throws {
+        emittedPayloads.append(try PayloadMergerImpl().merge(context: context, data: data))
+    }
+
+    func shutdown() {}
+
+    func flush() {}
 }
 
 final class DispatchQueueFake: DispatchQueueType {

--- a/Tests/ConfidenceTests/ConfidenceTest.swift
+++ b/Tests/ConfidenceTests/ConfidenceTest.swift
@@ -885,10 +885,10 @@ class ConfidenceTest: XCTestCase {
             debugLogger: nil
         )
 
+        confidence.putContext(context: ["session": ConfidenceValue(string: "ignored")])
         try confidence.track(
             eventName: "test",
-            data: ["context": ConfidenceValue(string: "override")],
-            eventContext: ["session": ConfidenceValue(string: "ignored")]
+            data: ["context": ConfidenceValue(string: "override")]
         )
 
         XCTAssertEqual(engine.emittedPayloads.count, 1)

--- a/Tests/ConfidenceTests/EventSenderEngineReliabilityTest.swift
+++ b/Tests/ConfidenceTests/EventSenderEngineReliabilityTest.swift
@@ -1,0 +1,118 @@
+import Foundation
+import XCTest
+
+@testable import Confidence
+
+final class EventSenderEngineReliabilityTest: XCTestCase {
+    // swiftlint:disable implicitly_unwrapped_optional
+    var writeQueue: DispatchQueue!
+    var uploaderMock: EventUploaderMock!
+    var storageMock: EventStorageMock!
+    // swiftlint:enable implicitly_unwrapped_optional
+
+    override func setUp() async throws {
+        writeQueue = DispatchQueue(label: "ConfidenceWriteQueue")
+        uploaderMock = EventUploaderMock()
+        storageMock = EventStorageMock()
+        try await super.setUp()
+    }
+
+    func testStartupUploadsPendingReadyBatchesWithoutSealingCurrentBatch() throws {
+        storageMock.events = [
+            ConfidenceEvent(name: "pending", payload: [:], eventTime: Date.backport.now)
+        ]
+        try storageMock.startNewBatch()
+        storageMock.events = [
+            ConfidenceEvent(name: "current", payload: [:], eventTime: Date.backport.now)
+        ]
+
+        let expectation = XCTestExpectation(description: "Startup upload finished")
+        let cancellable = uploaderMock.subject.sink { _ in
+            expectation.fulfill()
+        }
+
+        _ = EventSenderEngineImpl(
+            clientSecret: "CLIENT_SECRET",
+            uploader: uploaderMock,
+            storage: storageMock,
+            flushPolicies: [],
+            writeQueue: writeQueue,
+            debugLogger: nil
+        )
+
+        wait(for: [expectation], timeout: 5)
+        XCTAssertEqual(uploaderMock.calledRequest?.count, 1)
+        XCTAssertEqual(uploaderMock.calledRequest?.first?.eventDefinition, "pending")
+        XCTAssertEqual(storageMock.events.count, 1)
+        XCTAssertEqual(storageMock.events.first?.name, "current")
+        cancellable.cancel()
+    }
+
+    func testShutdownUploadsCurrentBatch() throws {
+        let eventSenderEngine = EventSenderEngineImpl(
+            clientSecret: "CLIENT_SECRET",
+            uploader: uploaderMock,
+            storage: storageMock,
+            flushPolicies: [],
+            writeQueue: writeQueue,
+            debugLogger: nil
+        )
+
+        let uploadExpectation = XCTestExpectation(description: "Shutdown upload finished")
+        let cancellable = uploaderMock.subject.sink { _ in
+            uploadExpectation.fulfill()
+        }
+
+        try eventSenderEngine.emit(eventName: "session-end", data: [:], context: [:])
+
+        eventSenderEngine.shutdown()
+
+        wait(for: [uploadExpectation], timeout: 5)
+        XCTAssertEqual(uploaderMock.calledRequest?.count, 1)
+        XCTAssertEqual(uploaderMock.calledRequest?.first?.eventDefinition, "session-end")
+        cancellable.cancel()
+    }
+
+    func testPeriodicFlushIntervalUploadsEvents() throws {
+        let eventSenderEngine = EventSenderEngineImpl(
+            clientSecret: "CLIENT_SECRET",
+            uploader: uploaderMock,
+            storage: storageMock,
+            flushPolicies: [],
+            writeQueue: writeQueue,
+            debugLogger: nil,
+            flushInterval: 0.1
+        )
+
+        let uploadExpectation = XCTestExpectation(description: "Interval upload finished")
+        let cancellable = uploaderMock.subject.sink { _ in
+            uploadExpectation.fulfill()
+        }
+
+        try eventSenderEngine.emit(eventName: "interval-event", data: [:], context: [:])
+        writeQueue.sync { }
+
+        wait(for: [uploadExpectation], timeout: 5)
+        XCTAssertEqual(uploaderMock.calledRequest?.first?.eventDefinition, "interval-event")
+        eventSenderEngine.shutdown()
+        cancellable.cancel()
+    }
+
+    func testEmitAfterShutdownIsDropped() throws {
+        let eventSenderEngine = EventSenderEngineImpl(
+            clientSecret: "CLIENT_SECRET",
+            uploader: uploaderMock,
+            storage: storageMock,
+            flushPolicies: [],
+            writeQueue: writeQueue,
+            debugLogger: nil
+        )
+
+        eventSenderEngine.shutdown()
+
+        try eventSenderEngine.emit(eventName: "after-shutdown", data: [:], context: [:])
+        writeQueue.sync { }
+
+        XCTAssertTrue(storageMock.events.isEmpty)
+    }
+}

--- a/Tests/ConfidenceTests/EventSenderEngineReliabilityTest.swift
+++ b/Tests/ConfidenceTests/EventSenderEngineReliabilityTest.swift
@@ -17,7 +17,7 @@ final class EventSenderEngineReliabilityTest: XCTestCase {
         try await super.setUp()
     }
 
-    func testStartupUploadsPendingReadyBatchesWithoutSealingCurrentBatch() throws {
+    func testStartupSealsAndUploadsRecoveredCurrentBatch() throws {
         storageMock.events = [
             ConfidenceEvent(name: "pending", payload: [:], eventTime: Date.backport.now)
         ]
@@ -27,6 +27,7 @@ final class EventSenderEngineReliabilityTest: XCTestCase {
         ]
 
         let expectation = XCTestExpectation(description: "Startup upload finished")
+        expectation.expectedFulfillmentCount = 2
         let cancellable = uploaderMock.subject.sink { _ in
             expectation.fulfill()
         }
@@ -41,10 +42,11 @@ final class EventSenderEngineReliabilityTest: XCTestCase {
         )
 
         wait(for: [expectation], timeout: 5)
-        XCTAssertEqual(uploaderMock.calledRequest?.count, 1)
-        XCTAssertEqual(uploaderMock.calledRequest?.first?.eventDefinition, "pending")
-        XCTAssertEqual(storageMock.events.count, 1)
-        XCTAssertEqual(storageMock.events.first?.name, "current")
+        let uploadedEventNames = uploaderMock.calledRequests
+            .flatMap { $0 }
+            .map(\.eventDefinition)
+        XCTAssertEqual(Set(uploadedEventNames), Set(["pending", "current"]))
+        XCTAssertTrue(storageMock.events.isEmpty)
         cancellable.cancel()
     }
 
@@ -114,5 +116,47 @@ final class EventSenderEngineReliabilityTest: XCTestCase {
         writeQueue.sync { }
 
         XCTAssertTrue(storageMock.events.isEmpty)
+    }
+
+    func testShutdownWaitIsBounded() throws {
+        let blockingUploader = BlockingEventUploaderMock()
+        let eventSenderEngine = EventSenderEngineImpl(
+            clientSecret: "CLIENT_SECRET",
+            uploader: blockingUploader,
+            storage: storageMock,
+            flushPolicies: [],
+            writeQueue: writeQueue,
+            debugLogger: nil,
+            shutdownTimeout: 0.05
+        )
+        try eventSenderEngine.emit(eventName: "pending", data: [:], context: [:])
+        writeQueue.sync { }
+
+        let shutdownFinished = expectation(description: "Shutdown wait finished")
+        DispatchQueue.global().async {
+            eventSenderEngine.shutdown()
+            shutdownFinished.fulfill()
+        }
+
+        wait(for: [shutdownFinished], timeout: 1)
+        blockingUploader.release()
+    }
+}
+
+private final class BlockingEventUploaderMock: ConfidenceClient {
+    private let uploadRelease = DispatchSemaphore(value: 0)
+
+    func upload(events: [NetworkEvent]) async throws -> Bool {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            DispatchQueue.global().async {
+                self.uploadRelease.wait()
+                continuation.resume()
+            }
+        }
+        return true
+    }
+
+    func release() {
+        uploadRelease.signal()
     }
 }

--- a/Tests/ConfidenceTests/EventStorageTests.swift
+++ b/Tests/ConfidenceTests/EventStorageTests.swift
@@ -29,6 +29,14 @@ class EventStorageTest: XCTestCase {
         XCTAssertEqual(events[1].name, "some event 2")
     }
 
+    func testEmptyCurrentBatchIsNotSealed() throws {
+        let eventStorage = try EventStorageImpl()
+
+        try eventStorage.startNewBatch()
+
+        XCTAssertTrue(try eventStorage.batchReadyIds().isEmpty)
+    }
+
     func testContinueWritingToOldBatch() throws {
         let eventStorage = try EventStorageImpl()
         try eventStorage.writeEvent(event: ConfidenceEvent(

--- a/Tests/ConfidenceTests/EventUploaderMock.swift
+++ b/Tests/ConfidenceTests/EventUploaderMock.swift
@@ -4,16 +4,19 @@ import Combine
 
 final class EventUploaderMock: ConfidenceClient {
     var calledRequest: [NetworkEvent]?
+    var calledRequests: [[NetworkEvent]] = []
     let subject: PassthroughSubject<Int, Never> = PassthroughSubject()
 
     func upload(events: [NetworkEvent]) async throws -> Bool {
         calledRequest = events
+        calledRequests.append(events)
         subject.send(1)
         return true
     }
 
     func reset() {
         calledRequest = nil
+        calledRequests.removeAll()
     }
 }
 
@@ -23,6 +26,9 @@ final class EventStorageMock: EventStorage {
     var removeCallback: () -> Void = {}
 
     func startNewBatch() throws {
+        guard !events.isEmpty else {
+            return
+        }
         batches[("\(batches.count)")] = events
         events.removeAll()
     }

--- a/Tests/ConfidenceTests/PayloadMergerTests.swift
+++ b/Tests/ConfidenceTests/PayloadMergerTests.swift
@@ -17,16 +17,17 @@ class PayloadMergerTests: XCTestCase {
         XCTAssertEqual(merged, expected)
     }
 
-    func testInvalidMessage() throws {
+    func testContextInDataOverridesEvaluationContext() throws {
         let context = ["a": ConfidenceValue(string: "hello"), "b": ConfidenceValue(string: "world")]
         let message = [
             "b": ConfidenceValue(string: "west"),
-            "context": ConfidenceValue(string: "world")  // simple value context is lost
+            "context": ConfidenceValue(string: "world")
         ]
-        XCTAssertThrowsError(
-            try PayloadMergerImpl().merge(context: context, data: message)
-        ) { error in
-            XCTAssertEqual(error as? ConfidenceError, ConfidenceError.invalidContextInMessage)
-        }
+        let expected = [
+            "b": ConfidenceValue(string: "west"),
+            "context": ConfidenceValue(string: "world")
+        ]
+        let merged = try PayloadMergerImpl().merge(context: context, data: message)
+        XCTAssertEqual(merged, expected)
     }
 }

--- a/api/ConfidenceProvider_public_api.json
+++ b/api/ConfidenceProvider_public_api.json
@@ -39,6 +39,10 @@
         "declaration": "public func getObjectEvaluation(key: String, defaultValue: OpenFeature.Value, context: EvaluationContext?)\nthrows -> OpenFeature.ProviderEvaluation<OpenFeature.Value>"
       },
       {
+        "name": "track(key:context:details:)",
+        "declaration": "public func track(key: String, context: (any EvaluationContext)?, details: (any TrackingEventDetails)?) throws"
+      },
+      {
         "name": "observe()",
         "declaration": "public func observe() -> AnyPublisher<OpenFeature.ProviderEvent, Never>"
       }

--- a/api/Confidence_public_api.json
+++ b/api/Confidence_public_api.json
@@ -95,10 +95,6 @@
         "declaration": "public func track(eventName: String, data: ConfidenceStruct) throws"
       },
       {
-        "name": "track(eventName:data:eventContext:)",
-        "declaration": "public func track(eventName: String, data: ConfidenceStruct, eventContext: ConfidenceStruct) throws"
-      },
-      {
         "name": "flush()",
         "declaration": "public func flush()"
       },

--- a/api/Confidence_public_api.json
+++ b/api/Confidence_public_api.json
@@ -212,6 +212,10 @@
         "declaration": "public init(stringList: [String])"
       },
       {
+        "name": "init(list:)",
+        "declaration": "public init(list: [ConfidenceValue])"
+      },
+      {
         "name": "init(integerList:)",
         "declaration": "public init(integerList: [Int])"
       },

--- a/api/Confidence_public_api.json
+++ b/api/Confidence_public_api.json
@@ -95,8 +95,16 @@
         "declaration": "public func track(eventName: String, data: ConfidenceStruct) throws"
       },
       {
+        "name": "track(eventName:data:eventContext:)",
+        "declaration": "public func track(eventName: String, data: ConfidenceStruct, eventContext: ConfidenceStruct) throws"
+      },
+      {
         "name": "flush()",
         "declaration": "public func flush()"
+      },
+      {
+        "name": "stop()",
+        "declaration": "public func stop()"
       }
     ]
   },
@@ -118,6 +126,10 @@
       {
         "name": "withTimeout(timeout:)",
         "declaration": "public func withTimeout(timeout: Double) -> Builder"
+      },
+      {
+        "name": "withEventFlushInterval(_:)",
+        "declaration": "public func withEventFlushInterval(_ interval: TimeInterval) -> Builder"
       },
       {
         "name": "build()",


### PR DESCRIPTION
Stacked on [#256](https://github.com/spotify/confidence-sdk-swift/pull/256) (`openfeature-0.6-migration`). Track + event reliability only — migration/iOS 15/OpenFeature 0.6.0 are in the base PR.

## Summary

- Implement OpenFeature `track(key:context:details:)` in `ConfidenceFeatureProvider`, forwarding to `confidence.track(eventName:data:eventContext:)` with stored client evaluation context merged with the Confidence session.
- Map OpenFeature tracking details and context to Confidence conventions (`key` → name, details → data; explicit `"value"` / `"context"` overrides).
- Improve event delivery reliability: optional interval flush via `withEventFlushInterval(_:)`, startup/shutdown flush, and provider `shutdown()` → `confidence.stop()`.

## Test plan

- [x] Provider track mapping and integration tests
- [x] `EventSenderEngineReliabilityTest`
- [ ] CI (Unit-Tests, Integration-Tests, API-diff, SwiftLint, DemoApp)

## Notes

Rebased onto `openfeature-0.6-migration` — conflicts resolved by dropping duplicate migration commits (now in #256).