### PR TITLE
feat: improve event delivery reliability for tracked events

### DIFF
--- a/Sources/Confidence/Confidence.swift
+++ b/Sources/Confidence/Confidence.swift
@@ -341,6 +341,14 @@ public class Confidence: ConfidenceEventSender {
     public func flush() {
         eventSenderEngine.flush()
     }
+
+    /**
+    Flush pending tracked events and shut down the event sender engine.
+    Call when the SDK is no longer needed, for example on app termination.
+    */
+    public func stop() {
+        eventSenderEngine.shutdown()
+    }
 }
 
 private class ContextManager {
@@ -398,6 +406,7 @@ extension Confidence {
         internal var region: ConfidenceRegion = .global
         internal var initialContext: ConfidenceStruct = [:]
         internal var timeout: Double = 10
+        internal var eventFlushInterval: TimeInterval?
 
         // Injectable for testing
         internal var flagApplier: FlagApplier?
@@ -466,6 +475,15 @@ extension Confidence {
         }
 
         /**
+        Set a periodic flush interval for tracked events, in seconds. Disabled by default.
+        When set, pending events are uploaded on this interval even if the batch size threshold has not been reached.
+        */
+        public func withEventFlushInterval(_ interval: TimeInterval) -> Builder {
+            self.eventFlushInterval = interval
+            return self
+        }
+
+        /**
         Build the Confidence instance.
         */
         public func build() -> Confidence {
@@ -509,7 +527,8 @@ extension Confidence {
                 clientSecret: clientSecret,
                 uploader: uploader,
                 storage: eventStorage,
-                debugLogger: debugLogger
+                debugLogger: debugLogger,
+                flushInterval: eventFlushInterval
             )
             return Confidence(
                 clientSecret: clientSecret,

--- a/Sources/Confidence/EventSenderEngine.swift
+++ b/Sources/Confidence/EventSenderEngine.swift
@@ -30,12 +30,15 @@ final class EventSenderEngineImpl: EventSenderEngine {
     private let semaphore = DispatchSemaphore(value: 1)
     private let writeQueue: DispatchQueue
     private let debugLogger: DebugLogger?
+    private var flushIntervalTimer: DispatchSourceTimer?
+    private var isShutdown = false
 
     convenience init(
         clientSecret: String,
         uploader: ConfidenceClient,
         storage: EventStorage,
-        debugLogger: DebugLogger?
+        debugLogger: DebugLogger?,
+        flushInterval: TimeInterval? = nil
     ) {
         self.init(
             clientSecret: clientSecret,
@@ -43,7 +46,8 @@ final class EventSenderEngineImpl: EventSenderEngine {
             storage: storage,
             flushPolicies: [SizeFlushPolicy(batchSize: 10)],
             writeQueue: DispatchQueue(label: "ConfidenceWriteQueue"),
-            debugLogger: debugLogger
+            debugLogger: debugLogger,
+            flushInterval: flushInterval
         )
     }
 
@@ -53,7 +57,8 @@ final class EventSenderEngineImpl: EventSenderEngine {
         storage: EventStorage,
         flushPolicies: [FlushPolicy],
         writeQueue: DispatchQueue,
-        debugLogger: DebugLogger?
+        debugLogger: DebugLogger?,
+        flushInterval: TimeInterval? = nil
     ) {
         self.uploader = uploader
         self.clientSecret = clientSecret
@@ -84,16 +89,26 @@ final class EventSenderEngineImpl: EventSenderEngine {
 
         uploadReqChannel.sink { [weak self] _ in
             guard let self = self else { return }
-            await self.upload()
+            await self.upload(sealCurrentBatch: true)
         }
         .store(in: &cancellables)
+
+        if let flushInterval, flushInterval > 0 {
+            startFlushIntervalTimer(flushInterval)
+        }
+
+        Task {
+            await self.upload(sealCurrentBatch: false)
+        }
     }
 
-    func upload() async {
+    func upload(sealCurrentBatch: Bool = true) async {
         await withSemaphore { [weak self] in
             guard let self = self else { return }
             do {
-                try self.storage.startNewBatch()
+                if sealCurrentBatch {
+                    try self.storage.startNewBatch()
+                }
                 let ids = try storage.batchReadyIds()
                 if ids.isEmpty {
                     return
@@ -138,6 +153,9 @@ final class EventSenderEngineImpl: EventSenderEngine {
         data: ConfidenceStruct,
         context: ConfidenceStruct
     ) throws {
+        guard !isShutdown else {
+            return
+        }
         let event = ConfidenceEvent(
             name: eventName,
             payload: try payloadMerger.merge(context: context, data: data),
@@ -152,10 +170,31 @@ final class EventSenderEngineImpl: EventSenderEngine {
     }
 
     func shutdown() {
+        isShutdown = true
+        flushIntervalTimer?.cancel()
+        flushIntervalTimer = nil
+
+        let shutdownComplete = DispatchSemaphore(value: 0)
+        Task {
+            await self.upload(sealCurrentBatch: true)
+            shutdownComplete.signal()
+        }
+        shutdownComplete.wait()
+
         for cancellable in cancellables {
             cancellable.cancel()
         }
         cancellables.removeAll()
+    }
+
+    private func startFlushIntervalTimer(_ interval: TimeInterval) {
+        let timer = DispatchSource.makeTimerSource(queue: writeQueue)
+        timer.schedule(deadline: .now() + interval, repeating: interval)
+        timer.setEventHandler { [weak self] in
+            self?.flush()
+        }
+        timer.resume()
+        flushIntervalTimer = timer
     }
 }
 

--- a/Sources/ConfidenceProvider/ConfidenceFeatureProvider.swift
+++ b/Sources/ConfidenceProvider/ConfidenceFeatureProvider.swift
@@ -56,7 +56,8 @@ public class ConfidenceFeatureProvider: FeatureProvider {
         }
     }
 
-    func shutdown() {
+    public func shutdown() {
+        confidence.flush()
         for cancellable in cancellables {
             cancellable.cancel()
         }

--- a/Tests/ConfidenceTests/EventSenderEngineReliabilityTest.swift
+++ b/Tests/ConfidenceTests/EventSenderEngineReliabilityTest.swift
@@ -4,9 +4,11 @@ import XCTest
 @testable import Confidence
 
 final class EventSenderEngineReliabilityTest: XCTestCase {
+    // swiftlint:disable implicitly_unwrapped_optional
     var writeQueue: DispatchQueue!
     var uploaderMock: EventUploaderMock!
     var storageMock: EventStorageMock!
+    // swiftlint:enable implicitly_unwrapped_optional
 
     override func setUp() async throws {
         writeQueue = DispatchQueue(label: "ConfidenceWriteQueue")

--- a/Tests/ConfidenceTests/EventSenderEngineReliabilityTest.swift
+++ b/Tests/ConfidenceTests/EventSenderEngineReliabilityTest.swift
@@ -1,0 +1,99 @@
+import Foundation
+import XCTest
+
+@testable import Confidence
+
+final class EventSenderEngineReliabilityTest: XCTestCase {
+    var writeQueue: DispatchQueue!
+    var uploaderMock: EventUploaderMock!
+    var storageMock: EventStorageMock!
+
+    override func setUp() async throws {
+        writeQueue = DispatchQueue(label: "ConfidenceWriteQueue")
+        uploaderMock = EventUploaderMock()
+        storageMock = EventStorageMock()
+        try await super.setUp()
+    }
+
+    func testStartupUploadsPendingReadyBatchesWithoutSealingCurrentBatch() throws {
+        storageMock.events = [
+            ConfidenceEvent(name: "pending", payload: [:], eventTime: Date.backport.now)
+        ]
+        try storageMock.startNewBatch()
+        storageMock.events = [
+            ConfidenceEvent(name: "current", payload: [:], eventTime: Date.backport.now)
+        ]
+
+        let expectation = XCTestExpectation(description: "Startup upload finished")
+        let cancellable = uploaderMock.subject.sink { _ in
+            expectation.fulfill()
+        }
+
+        _ = EventSenderEngineImpl(
+            clientSecret: "CLIENT_SECRET",
+            uploader: uploaderMock,
+            storage: storageMock,
+            flushPolicies: [],
+            writeQueue: writeQueue,
+            debugLogger: nil
+        )
+
+        wait(for: [expectation], timeout: 5)
+        XCTAssertEqual(uploaderMock.calledRequest?.count, 1)
+        XCTAssertEqual(uploaderMock.calledRequest?.first?.eventDefinition, "pending")
+        XCTAssertEqual(storageMock.events.count, 1)
+        XCTAssertEqual(storageMock.events.first?.name, "current")
+        cancellable.cancel()
+    }
+
+    func testShutdownUploadsCurrentBatch() throws {
+        let eventSenderEngine = EventSenderEngineImpl(
+            clientSecret: "CLIENT_SECRET",
+            uploader: uploaderMock,
+            storage: storageMock,
+            flushPolicies: [],
+            writeQueue: writeQueue,
+            debugLogger: nil
+        )
+
+        let uploadExpectation = XCTestExpectation(description: "Shutdown upload finished")
+        let cancellable = uploaderMock.subject.sink { _ in
+            uploadExpectation.fulfill()
+        }
+
+        try eventSenderEngine.emit(eventName: "session-end", data: [:], context: [:])
+        writeQueue.sync { }
+
+        eventSenderEngine.shutdown()
+
+        wait(for: [uploadExpectation], timeout: 5)
+        XCTAssertEqual(uploaderMock.calledRequest?.count, 1)
+        XCTAssertEqual(uploaderMock.calledRequest?.first?.eventDefinition, "session-end")
+        cancellable.cancel()
+    }
+
+    func testPeriodicFlushIntervalUploadsEvents() throws {
+        let eventSenderEngine = EventSenderEngineImpl(
+            clientSecret: "CLIENT_SECRET",
+            uploader: uploaderMock,
+            storage: storageMock,
+            flushPolicies: [],
+            writeQueue: writeQueue,
+            debugLogger: nil,
+            flushInterval: 0.1
+        )
+
+        let uploadExpectation = XCTestExpectation(description: "Interval upload finished")
+        let cancellable = uploaderMock.subject.sink { _ in
+            uploadExpectation.fulfill()
+        }
+
+        try eventSenderEngine.emit(eventName: "interval-event", data: [:], context: [:])
+        writeQueue.sync { }
+
+        wait(for: [uploadExpectation], timeout: 5)
+        XCTAssertEqual(uploaderMock.calledRequest?.first?.eventDefinition, "interval-event")
+        eventSenderEngine.shutdown()
+        cancellable.cancel()
+    }
+}

--- a/api/ConfidenceProvider_public_api.json
+++ b/api/ConfidenceProvider_public_api.json
@@ -11,6 +11,10 @@
         "declaration": "public func initialize(initialContext: OpenFeature.EvaluationContext?) async throws"
       },
       {
+        "name": "shutdown()",
+        "declaration": "public func shutdown()"
+      },
+      {
         "name": "onContextSet(oldContext:newContext:)",
         "declaration": "public func onContextSet(\n    oldContext: OpenFeature.EvaluationContext?,\n    newContext: OpenFeature.EvaluationContext\n) async"
       },

--- a/api/Confidence_public_api.json
+++ b/api/Confidence_public_api.json
@@ -93,6 +93,10 @@
       {
         "name": "flush()",
         "declaration": "public func flush()"
+      },
+      {
+        "name": "stop()",
+        "declaration": "public func stop()"
       }
     ]
   },
@@ -114,6 +118,10 @@
       {
         "name": "withTimeout(timeout:)",
         "declaration": "public func withTimeout(timeout: Double) -> Builder"
+      },
+      {
+        "name": "withEventFlushInterval(_:)",
+        "declaration": "public func withEventFlushInterval(_ interval: TimeInterval) -> Builder"
       },
       {
         "name": "build()",

--- a/scripts/api_diff.sh
+++ b/scripts/api_diff.sh
@@ -12,8 +12,13 @@ if [ -z "$1" ]; then
 fi
 MODULE=$1 
 
+SIMULATOR=$(xcrun simctl list devices available -j | \
+    python3 "$root_dir/.github/scripts/find-simulator.py" iOS)
+
+echo "Using simulator: $SIMULATOR"
+
 # Generate the json file with:
-sourcekitten doc --module-name ${MODULE} -- -scheme Confidence-Package -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=18.5' > $script_dir/${MODULE}_raw_api.json
+sourcekitten doc --module-name ${MODULE} -- -scheme Confidence-Package -destination "id=$SIMULATOR" > $script_dir/${MODULE}_raw_api.json
 
 # Extract the public API from the raw api json file
 python3 $script_dir/extract_public_funcs.py $script_dir/${MODULE}_raw_api.json $script_dir/${MODULE}_current_public_api.json


### PR DESCRIPTION
## Summary
- Upload pending `.ready` batches at engine startup (retries events from prior sessions without sealing the current file)
- Add `Confidence.stop()` to flush and upload the current batch before shutting down the event engine
- Add optional `Builder.withEventFlushInterval(_:)` for periodic flush (disabled by default)
- Call `confidence.flush()` from provider `shutdown()` as a best-effort lifecycle hook

## Test plan
- [ ] `./scripts/run_tests.sh --filter EventSenderEngineReliabilityTest`
- [ ] Verify startup uploads only pending batches and leaves the current file intact
- [ ] Verify `stop()` uploads in-flight events
- [ ] Verify periodic interval triggers upload when configured


Made with [Cursor](https://cursor.com)