### PR TITLE
fix: cancel in-flight initialize when context changes

### DIFF
--- a/Sources/Confidence/Confidence.swift
+++ b/Sources/Confidence/Confidence.swift
@@ -107,6 +107,7 @@ public class Confidence: ConfidenceEventSender {
     private func internalFetch() async throws {
         let context = getContext()
         let resolvedFlags = try await remoteFlagResolver.resolve(ctx: context)
+        try Task.checkCancellation()
         let resolution = FlagResolution(
             context: context,
             flags: resolvedFlags.resolvedValues,
@@ -184,13 +185,40 @@ public class Confidence: ConfidenceEventSender {
 
     /**
     Applies context and fetches flags for it.
-    Returns success only when the fetch is stored and activated; does not throw.
+    Returns success only when the fetch is stored and activated for this call; does not throw.
+    If a later context change supersedes this one, returns `CancellationError`.
     */
     public func reconcileContext(
         context: ConfidenceStruct,
         removedKeys: [String] = []
     ) async -> Result<Void, Error> {
-        await scheduleContextChange(context: context, removedKeys: removedKeys, logAction: "PutContext")
+        await scheduleOwnedContextChange(
+            context: context,
+            removedKeys: removedKeys,
+            logAction: "PutContext"
+        )
+    }
+
+    /**
+    Applies context and loads flags according to `strategy`.
+    If a later context change supersedes this call, returns `CancellationError`.
+    */
+    public func applyContext(
+        context: ConfidenceStruct,
+        strategy: InitializationStrategy,
+        removedKeys: [String] = []
+    ) async -> Result<Void, Error> {
+        switch strategy {
+        case .fetchAndActivate:
+            return await scheduleOwnedContextChange(
+                context: context,
+                removedKeys: removedKeys,
+                logAction: "PutContext",
+                ignoreFetchFailure: true
+            )
+        case .activateAndFetchAsync:
+            return await activateThenPrefetch(context: context, removedKeys: removedKeys)
+        }
     }
 
     /**
@@ -204,35 +232,23 @@ public class Confidence: ConfidenceEventSender {
     }
 
     public func putContext(key: String, value: ConfidenceValue) {
-        taskManager.currentTask = Task {
-            await self.performContextChange(context: [key: value], removedKeys: [], logAction: "PutContext")
-        }
+        startContextChange(context: [key: value], removedKeys: [], logAction: "PutContext")
     }
 
     public func putContext(context: ConfidenceStruct) {
-        taskManager.currentTask = Task {
-            await self.performContextChange(context: context, removedKeys: [], logAction: "PutContext")
-        }
+        startContextChange(context: context, removedKeys: [], logAction: "PutContext")
     }
 
     public func putContext(context: ConfidenceStruct, removeKeys removedKeys: [String] = []) {
-        taskManager.currentTask = Task {
-            await self.performContextChange(
-                context: context, removedKeys: removedKeys, logAction: "PutContext")
-        }
+        startContextChange(context: context, removedKeys: removedKeys, logAction: "PutContext")
     }
 
     public func removeContext(key: String) {
-        taskManager.currentTask = Task {
-            await self.performContextChange(context: [:], removedKeys: [key], logAction: "RemoveContext")
-        }
+        startContextChange(context: [:], removedKeys: [key], logAction: "RemoveContext")
     }
 
     public func putContext(context: ConfidenceStruct, removedKeys: [String]) {
-        taskManager.currentTask = Task {
-            await self.performContextChange(
-                context: context, removedKeys: removedKeys, logAction: "RemoveContext")
-        }
+        startContextChange(context: context, removedKeys: removedKeys, logAction: "RemoveContext")
     }
 
     /**
@@ -247,37 +263,140 @@ public class Confidence: ConfidenceEventSender {
         removedKeys: [String],
         logAction: String
     ) async -> Result<Void, Error> {
-        taskManager.currentTask = Task {
-            await self.performContextChange(
-                context: context, removedKeys: removedKeys, logAction: logAction)
-        }
+        startContextChange(context: context, removedKeys: removedKeys, logAction: logAction)
         return await taskManager.awaitReconciliation()
     }
 
-    private func performContextChange(
+    private func scheduleOwnedContextChange(
         context: ConfidenceStruct,
         removedKeys: [String],
-        logAction: String
+        logAction: String,
+        ignoreFetchFailure: Bool = false
+    ) async -> Result<Void, Error> {
+        let task = startContextChange(
+            context: context,
+            removedKeys: removedKeys,
+            logAction: logAction,
+            ignoreFetchFailure: ignoreFetchFailure
+        )
+        return await ownedResult(of: task)
+    }
+
+    @discardableResult
+    private func startContextChange(
+        context: ConfidenceStruct,
+        removedKeys: [String],
+        logAction: String,
+        ignoreFetchFailure: Bool = false
+    ) -> Task<Result<Void, Error>, Never> {
+        taskManager.start(applying: {
+            _ = self.contextManager.updateContext(withValues: context, removedKeys: removedKeys)
+        }, operation: {
+            await self.performFetchAndActivate(
+                logAction: logAction,
+                ignoreFetchFailure: ignoreFetchFailure
+            )
+        })
+    }
+
+    private func ownedResult(
+        of task: Task<Result<Void, Error>, Never>
+    ) async -> Result<Void, Error> {
+        let result = await task.value
+        if task.isCancelled || !taskManager.isCurrent(task) {
+            return .failure(CancellationError())
+        }
+        return result
+    }
+
+    private func activateThenPrefetch(
+        context: ConfidenceStruct,
+        removedKeys: [String]
+    ) async -> Result<Void, Error> {
+        await withCheckedContinuation { continuation in
+            let resume = OnceResume(continuation)
+            _ = taskManager.start(applying: {
+                _ = self.contextManager.updateContext(withValues: context, removedKeys: removedKeys)
+            }, operation: {
+                if Task.isCancelled {
+                    resume.finish(.failure(CancellationError()))
+                    return .failure(CancellationError())
+                }
+                do {
+                    try self.activate()
+                } catch {
+                    resume.finish(.failure(error))
+                    return .failure(error)
+                }
+                resume.finish(.success(()))
+                if Task.isCancelled {
+                    return .failure(CancellationError())
+                }
+                do {
+                    try await self.internalFetch()
+                    return .success(())
+                } catch {
+                    if self.isCancellation(error) {
+                        return .failure(CancellationError())
+                    }
+                    self.debugLogger?.logMessage(
+                        message: "\(error)",
+                        isWarning: true
+                    )
+                    return .failure(error)
+                }
+            })
+        }
+    }
+
+    private func performFetchAndActivate(
+        logAction: String,
+        ignoreFetchFailure: Bool
     ) async -> Result<Void, Error> {
         if Task.isCancelled {
             return .failure(CancellationError())
         }
 
-        let newContext = contextManager.updateContext(withValues: context, removedKeys: removedKeys)
         do {
-            try await internalFetch()
+            do {
+                try await internalFetch()
+            } catch {
+                if isCancellation(error) {
+                    throw CancellationError()
+                }
+                if !ignoreFetchFailure {
+                    throw error
+                }
+                debugLogger?.logMessage(
+                    message: "\(error)",
+                    isWarning: true
+                )
+            }
+            try Task.checkCancellation()
             try activate()
-            debugLogger?.logContext(action: logAction, context: newContext)
+            debugLogger?.logContext(action: logAction, context: getContext())
             return .success(())
-        } catch is CancellationError {
-            return .failure(CancellationError())
         } catch {
+            if isCancellation(error) {
+                return .failure(CancellationError())
+            }
             debugLogger?.logMessage(
                 message: "Error when putting context: \(error)",
                 isWarning: true)
             try? activate()
             return .failure(error)
         }
+    }
+
+    private func isCancellation(_ error: Error) -> Bool {
+        if error is CancellationError {
+            return true
+        }
+        if Task.isCancelled {
+            return true
+        }
+        let nsError = error as NSError
+        return nsError.domain == NSURLErrorDomain && nsError.code == NSURLErrorCancelled
     }
 
     public func withContext(_ context: ConfidenceStruct) -> ConfidenceEventSender {
@@ -337,6 +456,23 @@ public class Confidence: ConfidenceEventSender {
 
     public func flush() {
         eventSenderEngine.flush()
+    }
+}
+
+private final class OnceResume<T> {
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<T, Never>?
+
+    init(_ continuation: CheckedContinuation<T, Never>) {
+        self.continuation = continuation
+    }
+
+    func finish(_ value: T) {
+        lock.lock()
+        let continuation = self.continuation
+        self.continuation = nil
+        lock.unlock()
+        continuation?.resume(returning: value)
     }
 }
 

--- a/Sources/Confidence/TaskManager.swift
+++ b/Sources/Confidence/TaskManager.swift
@@ -16,6 +16,29 @@ internal class TaskManager {
         }
     }
 
+    /// Cancels any in-flight task, optionally applies state, then starts `operation` as the current generation.
+    @discardableResult
+    func start(
+        applying: (() -> Void)? = nil,
+        operation: @escaping () async -> Result<Void, Error>
+    ) -> Task<Result<Void, Error>, Never> {
+        queue.sync {
+            if let oldTask = _currentTask {
+                oldTask.cancel()
+            }
+            applying?()
+            let task = Task<Result<Void, Error>, Never> {
+                await operation()
+            }
+            _currentTask = task
+            return task
+        }
+    }
+
+    func isCurrent(_ task: Task<Result<Void, Error>, Never>) -> Bool {
+        queue.sync { _currentTask == task }
+    }
+
     @discardableResult
     public func awaitReconciliation() async -> Result<Void, Error> {
         while let task = self.currentTask {

--- a/Sources/ConfidenceProvider/ConfidenceFeatureProvider.swift
+++ b/Sources/ConfidenceProvider/ConfidenceFeatureProvider.swift
@@ -50,25 +50,8 @@ public class ConfidenceFeatureProvider: FeatureProvider {
     public func initialize(initialContext: OpenFeature.EvaluationContext?) -> Future<Void, Never> {
         Future { promise in
             Task {
-                do {
-                    let context = ConfidenceTypeMapper.from(
-                        ctx: initialContext ?? ImmutableContext(attributes: [:])
-                    )
-                    self.confidence.putContextLocal(context: context)
-                    if self.initializationStrategy == .activateAndFetchAsync {
-                        try self.confidence.activate()
-                        self.statusTracker.send(.ready(nil))
-                        promise(.success(()))
-                        await self.confidence.asyncFetch()
-                    } else {
-                        try await self.confidence.fetchAndActivate()
-                        self.statusTracker.send(.ready(nil))
-                        promise(.success(()))
-                    }
-                } catch {
-                    self.statusTracker.send(.error(ProviderEventDetails(message: error.localizedDescription)))
-                    promise(.success(()))
-                }
+                await self.performInitialize(initialContext: initialContext)
+                promise(.success(()))
             }
         }
     }
@@ -87,25 +70,11 @@ public class ConfidenceFeatureProvider: FeatureProvider {
         Future { promise in
             Task {
                 self.statusTracker.send(.reconciling(nil))
-                let newContextMap = newContext.asMap()
-                let newKeys = Set(Array(newContextMap.keys))
-                let targetingKey = newContext.getTargetingKey()
-
-                let removedKeys: [String] = oldContext.map { oldCtx in
-                    let oldKeys = Array(oldCtx.asMap().keys)
-                    return Array(Set(oldKeys).subtracting(newKeys))
-                } ?? []
-
                 let result = await self.confidence.reconcileContext(
-                    context: ConfidenceTypeMapper.from(contextMap: newContextMap, targetingKey: targetingKey),
-                    removedKeys: removedKeys
+                    context: ConfidenceTypeMapper.from(ctx: newContext),
+                    removedKeys: self.removedKeys(oldContext: oldContext, newContext: newContext)
                 )
-                switch result {
-                case .success:
-                    self.statusTracker.send(.contextChanged(nil))
-                case .failure(let error):
-                    self.statusTracker.send(.stale(ProviderEventDetails(message: error.localizedDescription)))
-                }
+                self.emitContextSetOutcome(result)
                 promise(.success(()))
             }
         }
@@ -158,6 +127,58 @@ public class ConfidenceFeatureProvider: FeatureProvider {
 
     public func observe() -> AnyPublisher<OpenFeature.ProviderEvent, Never> {
         statusTracker.observe()
+    }
+
+    private func performInitialize(initialContext: OpenFeature.EvaluationContext?) async {
+        let context = ConfidenceTypeMapper.from(
+            ctx: initialContext ?? ImmutableContext(attributes: [:])
+        )
+        let result = await confidence.applyContext(
+            context: context,
+            strategy: initializationStrategy
+        )
+        emitInitializeOutcome(result)
+    }
+
+    private func emitInitializeOutcome(_ result: Result<Void, Error>) {
+        switch result {
+        case .success:
+            statusTracker.send(.ready(nil))
+        case .failure(let error) where isCancellation(error):
+            break
+        case .failure(let error):
+            statusTracker.send(.error(ProviderEventDetails(message: error.localizedDescription)))
+        }
+    }
+
+    private func emitContextSetOutcome(_ result: Result<Void, Error>) {
+        switch result {
+        case .success:
+            statusTracker.send(.contextChanged(nil))
+        case .failure(let error) where isCancellation(error):
+            break
+        case .failure(let error):
+            statusTracker.send(.stale(ProviderEventDetails(message: error.localizedDescription)))
+        }
+    }
+
+    private func removedKeys(
+        oldContext: OpenFeature.EvaluationContext?,
+        newContext: OpenFeature.EvaluationContext
+    ) -> [String] {
+        let newKeys = Set(Array(newContext.asMap().keys))
+        return oldContext.map { oldCtx in
+            let oldKeys = Array(oldCtx.asMap().keys)
+            return Array(Set(oldKeys).subtracting(newKeys))
+        } ?? []
+    }
+
+    private func isCancellation(_ error: Error) -> Bool {
+        if error is CancellationError {
+            return true
+        }
+        let nsError = error as NSError
+        return nsError.domain == NSURLErrorDomain && nsError.code == NSURLErrorCancelled
     }
 
     private func withLock(callback: @escaping (ConfidenceFeatureProvider) -> Void) {

--- a/Tests/ConfidenceProviderTests/ConfidenceProviderTest.swift
+++ b/Tests/ConfidenceProviderTests/ConfidenceProviderTest.swift
@@ -900,6 +900,183 @@ class ConfidenceProviderTest: XCTestCase {
         XCTAssertNil(evaluation.errorCode)
         XCTAssertNil(evaluation.errorMessage)
     }
+
+    func testContextChangeDuringInitializationKeepsLatestFlags() async throws {
+        let firstStarted = expectation(description: "initial resolve started")
+        let firstCancelled = expectation(description: "initial resolve cancelled")
+        let client = DelayTargetingKeyClient(
+            delayKey: "user1",
+            delayedStarted: firstStarted,
+            delayedCancelled: firstCancelled
+        )
+        let confidence = Confidence.Builder(clientSecret: "test")
+            .withFlagResolverClient(flagResolver: client)
+            .withStorage(storage: StorageMock())
+            .build()
+        let provider = ConfidenceFeatureProvider(
+            confidence: confidence,
+            initializationStrategy: .fetchAndActivate
+        )
+
+        let initialize = provider.initialize(
+            initialContext: ImmutableContext(targetingKey: "user1")
+        )
+        await fulfillment(of: [firstStarted], timeout: 1)
+        let contextSet = provider.onContextSet(
+            oldContext: ImmutableContext(targetingKey: "user1"),
+            newContext: ImmutableContext(targetingKey: "user2")
+        )
+        await wait(initialize)
+        await wait(contextSet)
+        await fulfillment(of: [firstCancelled], timeout: 1)
+
+        XCTAssertEqual(provider.status, .ready)
+        let evaluation = try provider.getIntegerEvaluation(
+            key: "flag.size",
+            defaultValue: 0,
+            context: nil
+        )
+        XCTAssertEqual(evaluation.value, 7)
+        XCTAssertEqual(evaluation.reason, ResolveReason.match.rawValue)
+    }
+
+    func testContextChangeDuringAsyncPrefetchKeepsLatestFlags() async throws {
+        let prefetchStarted = expectation(description: "prefetch started")
+        let prefetchCancelled = expectation(description: "prefetch cancelled")
+        let client = DelayTargetingKeyClient(
+            delayKey: "user1",
+            delayedStarted: prefetchStarted,
+            delayedCancelled: prefetchCancelled
+        )
+        let confidence = Confidence.Builder(clientSecret: "test")
+            .withFlagResolverClient(flagResolver: client)
+            .withStorage(storage: StorageMock())
+            .build()
+        let provider = ConfidenceFeatureProvider(
+            confidence: confidence,
+            initializationStrategy: .activateAndFetchAsync
+        )
+
+        await wait(provider.initialize(initialContext: ImmutableContext(targetingKey: "user1")))
+        XCTAssertEqual(provider.status, .ready)
+        await fulfillment(of: [prefetchStarted], timeout: 1)
+        await wait(provider.onContextSet(
+            oldContext: ImmutableContext(targetingKey: "user1"),
+            newContext: ImmutableContext(targetingKey: "user2")
+        ))
+        await fulfillment(of: [prefetchCancelled], timeout: 1)
+
+        XCTAssertEqual(provider.status, .ready)
+        let evaluation = try provider.getIntegerEvaluation(
+            key: "flag.size",
+            defaultValue: 0,
+            context: nil
+        )
+        XCTAssertEqual(evaluation.value, 7)
+        XCTAssertEqual(evaluation.reason, ResolveReason.match.rawValue)
+    }
+
+    func testOverlappingContextChangesKeepLatestFlags() async throws {
+        let delayedStarted = expectation(description: "first context resolve started")
+        let delayedCancelled = expectation(description: "first context resolve cancelled")
+        let client = DelayTargetingKeyClient(
+            delayKey: "user2",
+            delayedStarted: delayedStarted,
+            delayedCancelled: delayedCancelled
+        )
+        let confidence = Confidence.Builder(clientSecret: "test")
+            .withFlagResolverClient(flagResolver: client)
+            .withStorage(storage: StorageMock())
+            .build()
+        let provider = ConfidenceFeatureProvider(
+            confidence: confidence,
+            initializationStrategy: .fetchAndActivate
+        )
+
+        await wait(provider.initialize(initialContext: ImmutableContext(targetingKey: "user1")))
+        let firstChange = provider.onContextSet(
+            oldContext: ImmutableContext(targetingKey: "user1"),
+            newContext: ImmutableContext(targetingKey: "user2")
+        )
+        await fulfillment(of: [delayedStarted], timeout: 1)
+        let secondChange = provider.onContextSet(
+            oldContext: ImmutableContext(targetingKey: "user2"),
+            newContext: ImmutableContext(targetingKey: "user3")
+        )
+        await wait(firstChange)
+        await wait(secondChange)
+        await fulfillment(of: [delayedCancelled], timeout: 1)
+
+        XCTAssertEqual(provider.status, .ready)
+        let evaluation = try provider.getIntegerEvaluation(
+            key: "flag.size",
+            defaultValue: 0,
+            context: nil
+        )
+        XCTAssertEqual(evaluation.value, 9)
+        XCTAssertEqual(evaluation.reason, ResolveReason.match.rawValue)
+    }
+
+    private func wait(_ future: Future<Void, Never>) async {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            var cancellable: AnyCancellable?
+            cancellable = future.sink { _ in
+                continuation.resume()
+                _ = cancellable
+            }
+        }
+    }
+}
+
+private class DelayTargetingKeyClient: ConfidenceResolveClient {
+    let delayKey: String
+    let delayedStarted: XCTestExpectation
+    let delayedCancelled: XCTestExpectation
+
+    init(
+        delayKey: String,
+        delayedStarted: XCTestExpectation,
+        delayedCancelled: XCTestExpectation
+    ) {
+        self.delayKey = delayKey
+        self.delayedStarted = delayedStarted
+        self.delayedCancelled = delayedCancelled
+    }
+
+    func resolve(ctx: ConfidenceStruct) async throws -> ResolvesResult {
+        let targetingKey = ctx["targeting_key"]?.asString() ?? ""
+        if targetingKey == delayKey {
+            delayedStarted.fulfill()
+            do {
+                try await Task.sleep(nanoseconds: 5_000_000_000)
+            } catch {
+                delayedCancelled.fulfill()
+                throw error
+            }
+            XCTFail("delayed resolve should have been cancelled")
+        }
+        let size: Int
+        switch targetingKey {
+        case "user2":
+            size = 7
+        case "user3":
+            size = 9
+        default:
+            size = 3
+        }
+        return .init(
+            resolvedValues: [
+                ResolvedValue(
+                    variant: "control",
+                    value: .init(structure: ["size": .init(integer: size)]),
+                    flag: "flag",
+                    resolveReason: .match,
+                    shouldApply: true
+                )
+            ],
+            resolveToken: "token"
+        )
+    }
 }
 
 private class StorageMock: Storage {

--- a/Tests/ConfidenceTests/CancellationStorageRaceTest.swift
+++ b/Tests/ConfidenceTests/CancellationStorageRaceTest.swift
@@ -1,0 +1,104 @@
+import Foundation
+import XCTest
+
+@testable import Confidence
+
+@available(macOS 13.0, iOS 16.0, *)
+final class CancellationStorageRaceTest: XCTestCase {
+    func testSupersededSaveCannotOverwriteLatestResolution() async throws {
+        let firstSaveStarted = expectation(description: "first save started")
+        let releaseFirstSave = DispatchSemaphore(value: 0)
+        defer { releaseFirstSave.signal() }
+        let storage = BlockingSaveStorage(
+            firstSaveStarted: firstSaveStarted,
+            releaseFirstSave: releaseFirstSave
+        )
+        let confidence = Confidence.Builder(clientSecret: "test")
+            .withFlagResolverClient(flagResolver: ImmediateTargetingClient())
+            .withStorage(storage: storage)
+            .build()
+
+        let first = Task {
+            await confidence.applyContext(
+                context: ["targeting_key": .init(string: "user1")],
+                strategy: .fetchAndActivate
+            )
+        }
+        await fulfillment(of: [firstSaveStarted], timeout: 1)
+
+        let second = await confidence.reconcileContext(
+            context: ["targeting_key": .init(string: "user2")]
+        )
+        guard case .success = second else {
+            XCTFail("second reconciliation should succeed")
+            return
+        }
+
+        releaseFirstSave.signal()
+        _ = await first.value
+
+        try confidence.activate()
+        XCTAssertEqual(confidence.getEvaluation(key: "flag.size", defaultValue: 0).value, 7)
+    }
+}
+
+private final class ImmediateTargetingClient: ConfidenceResolveClient {
+    func resolve(ctx: ConfidenceStruct) async throws -> ResolvesResult {
+        let size = ctx["targeting_key"]?.asString() == "user2" ? 7 : 3
+        return .init(
+            resolvedValues: [
+                ResolvedValue(
+                    variant: "control",
+                    value: .init(structure: ["size": .init(integer: size)]),
+                    flag: "flag",
+                    resolveReason: .match,
+                    shouldApply: true
+                )
+            ],
+            resolveToken: "token"
+        )
+    }
+}
+
+private final class BlockingSaveStorage: Storage {
+    private let lock = NSLock()
+    private let firstSaveStarted: XCTestExpectation
+    private let releaseFirstSave: DispatchSemaphore
+    private var resolution: FlagResolution?
+
+    init(firstSaveStarted: XCTestExpectation, releaseFirstSave: DispatchSemaphore) {
+        self.firstSaveStarted = firstSaveStarted
+        self.releaseFirstSave = releaseFirstSave
+    }
+
+    func save(data: Encodable) throws {
+        let newResolution = try XCTUnwrap(data as? FlagResolution)
+        if newResolution.context["targeting_key"]?.asString() == "user1" {
+            firstSaveStarted.fulfill()
+            releaseFirstSave.wait()
+        }
+        lock.lock()
+        resolution = newResolution
+        lock.unlock()
+    }
+
+    func load<T>(defaultValue: T) throws -> T where T: Decodable {
+        lock.lock()
+        let value = resolution
+        lock.unlock()
+        return (value as? T) ?? defaultValue
+    }
+
+    func clear() throws {
+        lock.lock()
+        resolution = nil
+        lock.unlock()
+    }
+
+    func isEmpty() -> Bool {
+        lock.lock()
+        let empty = resolution == nil
+        lock.unlock()
+        return empty
+    }
+}

--- a/Tests/ConfidenceTests/ConfidenceTest.swift
+++ b/Tests/ConfidenceTests/ConfidenceTest.swift
@@ -466,6 +466,77 @@ class ConfidenceTest: XCTestCase {
         await confidence.putContextAndWait(context: ["hello": .init(string: "world")])
     }
 
+    func testApplyContextSupersededByReconcileKeepsLatestFlags() async throws {
+        let firstStarted = expectation(description: "first resolve started")
+        let firstCancelled = expectation(description: "first resolve cancelled")
+        let client = DelayTargetingKeyClient(
+            delayKey: "user1",
+            delayedStarted: firstStarted,
+            delayedCancelled: firstCancelled
+        )
+        let confidence = Confidence.Builder(clientSecret: "test")
+            .withFlagResolverClient(flagResolver: client)
+            .withStorage(storage: StorageMock())
+            .build()
+
+        let initializeTask = Task {
+            await confidence.applyContext(
+                context: ["targeting_key": .init(string: "user1")],
+                strategy: .fetchAndActivate
+            )
+        }
+        await fulfillment(of: [firstStarted], timeout: 1)
+        let reconcileResult = await confidence.reconcileContext(
+            context: ["targeting_key": .init(string: "user2")]
+        )
+        let initializeResult = await initializeTask.value
+        await fulfillment(of: [firstCancelled], timeout: 1)
+
+        guard case .failure = initializeResult else {
+            XCTFail("initialize should be superseded")
+            return
+        }
+        guard case .success = reconcileResult else {
+            XCTFail("reconcile should succeed")
+            return
+        }
+        XCTAssertEqual(confidence.getEvaluation(key: "flag.size", defaultValue: 0).value, 7)
+    }
+
+    func testActivateThenPrefetchSupersededByReconcileKeepsLatestFlags() async throws {
+        let firstStarted = expectation(description: "prefetch started")
+        let firstCancelled = expectation(description: "prefetch cancelled")
+        let client = DelayTargetingKeyClient(
+            delayKey: "user1",
+            delayedStarted: firstStarted,
+            delayedCancelled: firstCancelled
+        )
+        let confidence = Confidence.Builder(clientSecret: "test")
+            .withFlagResolverClient(flagResolver: client)
+            .withStorage(storage: StorageMock())
+            .build()
+
+        let applyResult = await confidence.applyContext(
+            context: ["targeting_key": .init(string: "user1")],
+            strategy: .activateAndFetchAsync
+        )
+        guard case .success = applyResult else {
+            XCTFail("activation should succeed before prefetch")
+            return
+        }
+        await fulfillment(of: [firstStarted], timeout: 1)
+        let reconcileResult = await confidence.reconcileContext(
+            context: ["targeting_key": .init(string: "user2")]
+        )
+        await fulfillment(of: [firstCancelled], timeout: 1)
+
+        guard case .success = reconcileResult else {
+            XCTFail("reconcile should succeed")
+            return
+        }
+        XCTAssertEqual(confidence.getEvaluation(key: "flag.size", defaultValue: 0).value, 7)
+    }
+
     func testResolveDoubleFlag() async throws {
         class FakeClient: ConfidenceResolveClient {
             var resolveStats: Int = 0
@@ -1426,6 +1497,49 @@ class ConfidenceTest: XCTestCase {
         XCTAssertEqual(evaluation.variant, "control")
         XCTAssertNil(evaluation.errorMessage)
         XCTAssertNil(evaluation.errorCode)
+    }
+}
+
+private class DelayTargetingKeyClient: ConfidenceResolveClient {
+    let delayKey: String
+    let delayedStarted: XCTestExpectation
+    let delayedCancelled: XCTestExpectation
+
+    init(
+        delayKey: String,
+        delayedStarted: XCTestExpectation,
+        delayedCancelled: XCTestExpectation
+    ) {
+        self.delayKey = delayKey
+        self.delayedStarted = delayedStarted
+        self.delayedCancelled = delayedCancelled
+    }
+
+    func resolve(ctx: ConfidenceStruct) async throws -> ResolvesResult {
+        let targetingKey = ctx["targeting_key"]?.asString() ?? ""
+        if targetingKey == delayKey {
+            delayedStarted.fulfill()
+            do {
+                try await Task.sleep(nanoseconds: 5_000_000_000)
+            } catch {
+                delayedCancelled.fulfill()
+                throw error
+            }
+            XCTFail("delayed resolve should have been cancelled")
+        }
+        let size = targetingKey == "user2" ? 7 : 3
+        return .init(
+            resolvedValues: [
+                ResolvedValue(
+                    variant: "control",
+                    value: .init(structure: ["size": .init(integer: size)]),
+                    flag: "flag",
+                    resolveReason: .match,
+                    shouldApply: true
+                )
+            ],
+            resolveToken: "token"
+        )
     }
 }
 

--- a/Tests/ConfidenceTests/TaskManagerTests.swift
+++ b/Tests/ConfidenceTests/TaskManagerTests.swift
@@ -91,6 +91,29 @@ class TaskManagerTests: XCTestCase {
         XCTAssertTrue(true)
     }
 
+    func testStartCancelsPreviousTask() async {
+        let taskManager = TaskManager()
+        let firstCancelled = XCTestExpectation(description: "first cancelled")
+        let first = taskManager.start {
+            do {
+                try await Task.sleep(nanoseconds: 10_000_000_000)
+                return .success(())
+            } catch {
+                firstCancelled.fulfill()
+                return .failure(error)
+            }
+        }
+        XCTAssertTrue(taskManager.isCurrent(first))
+
+        let second = taskManager.start {
+            .success(())
+        }
+        XCTAssertFalse(taskManager.isCurrent(first))
+        XCTAssertTrue(taskManager.isCurrent(second))
+        _ = await second.value
+        await fulfillment(of: [firstCancelled], timeout: 1)
+    }
+
     private actor SignalManager {
         private var _signal1 = false
         private var _signal2 = false

--- a/api/Confidence_public_api.json
+++ b/api/Confidence_public_api.json
@@ -55,6 +55,10 @@
         "declaration": "public func reconcileContext(\n    context: ConfidenceStruct,\n    removedKeys: [String] = []\n) async -> Result<Void, Error>"
       },
       {
+        "name": "applyContext(context:strategy:removedKeys:)",
+        "declaration": "public func applyContext(\n    context: ConfidenceStruct,\n    strategy: InitializationStrategy,\n    removedKeys: [String] = []\n) async -> Result<Void, Error>"
+      },
+      {
         "name": "putContextLocal(context:removeKeys:)",
         "declaration": "public func putContextLocal(context: ConfidenceStruct, removeKeys removedKeys: [String] = [])"
       },


### PR DESCRIPTION
## Summary
- Route `initialize` and `onContextSet` through the same `TaskManager` generation so a later context change cancels in-flight init/prefetch instead of racing it.
- Emit `.ready` / `.contextChanged` / `.stale` only if that call is still current; a superseded fetch cannot overwrite flags or status.
- Add overlap tests for `fetchAndActivate` init, `activateAndFetchAsync` prefetch, and stacked `onContextSet` calls.

## Why not FIFO
OpenFeature 0.6 serializes lifecycle *call starts*, not Future completion. [#261](https://github.com/spotify/confidence-sdk-swift/pull/261) queues the work so initialize always finishes first. This PR follows the SDK's existing cancel-and-supersede model (and OpenFeature's guidance) so the app does not wait on a resolve for a context it already replaced.

Stacked on [#259](https://github.com/spotify/confidence-sdk-swift/pull/259).

## Test plan
- [x] `swift test --skip ConfidenceIntegrationTest --skip MixedTypesFlagIntegrationTest`
- [x] `swiftlint lint --strict` on touched files
- [ ] CI (Unit-Tests, Integration-Tests, API-diff, SwiftLint)


Made with [Cursor](https://cursor.com)