### PR TITLE
feat: expose resolve storage status

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,14 +80,43 @@ There is also an `async/await` compatible API available for waiting the Provider
 await OpenFeatureAPI.shared.setProviderAndWait(provider: provider)
 ```
 
-A utility function is available on the provider to check if the current storage has any stored values - this can be used to determine the best initialization strategy.
+Choose an initialization strategy based on the age of the stored resolution:
 ```swift
-// If we have no cache, then do a fetch first.
-var initializationStrategy: InitializationStrategy = .activateAndFetchAsync
-if ConfidenceFeatureProvider.isStorageEmpty() {
+let status = try confidence.getStorageStatus(check: MaxAgeStorageCheck(maxAge: 24 * 60 * 60))
+let initializationStrategy: InitializationStrategy
+switch status {
+case .empty, .stale:
     initializationStrategy = .fetchAndActivate
+case .fresh:
+    initializationStrategy = .activateAndFetchAsync
+}
+let provider = ConfidenceFeatureProvider(
+    confidence: confidence,
+    initializationStrategy: initializationStrategy
+)
+```
+
+`maxAge` is a positive, finite interval in seconds. A cache is stale at or beyond that age;
+older caches without a fetch timestamp are also stale. Successful fetches persist the timestamp
+with the resolution, even before activation. Failed fetches leave the timestamp unchanged.
+Checking status does not fetch or activate flags, and storage read errors are thrown to the caller.
+
+Implement `ResolveStorageCheck` for custom rules, such as checking the stored evaluation context:
+```swift
+struct UserStorageCheck: ResolveStorageCheck {
+    let expectedUser: ConfidenceValue
+
+    func check(metadata: ResolveStorageMetadata) -> ResolveStorageStatus {
+        if metadata.isEmpty { return .empty }
+        if metadata.context["targeting_key"] != expectedUser {
+            return .stale(lastFetchedAt: metadata.lastFetchedAt)
+        }
+        return MaxAgeStorageCheck(maxAge: 24 * 60 * 60).check(metadata: metadata)
+    }
 }
 ```
+
+`confidence.isStorageEmpty()` remains available when only cache presence matters.
 
 Initialization strategies:
 - _activateAndFetchAsync_: the flags in the cached are used for this session, while updated values are fetched and stored on disk for a future session; this means that a READY event is immediately emitted when calling `setProvider()`;

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ struct UserStorageCheck: ResolveStorageCheck {
 
     func check(metadata: ResolveStorageMetadata) -> ResolveStorageStatus {
         if metadata.isEmpty { return .empty }
-        if metadata.context["targeting_key"] != expectedUser {
+        if metadata.context["user_id"] != expectedUser {
             return .stale(lastFetchedAt: metadata.lastFetchedAt)
         }
         return MaxAgeStorageCheck(maxAge: 24 * 60 * 60).check(metadata: metadata)

--- a/Sources/Confidence/Confidence.swift
+++ b/Sources/Confidence/Confidence.swift
@@ -110,7 +110,8 @@ public class Confidence: ConfidenceEventSender {
         let resolution = FlagResolution(
             context: context,
             flags: resolvedFlags.resolvedValues,
-            resolveToken: resolvedFlags.resolveToken ?? ""
+            resolveToken: resolvedFlags.resolveToken ?? "",
+            lastFetchedAt: Date()
         )
         try storage.save(data: resolution)
     }
@@ -120,6 +121,18 @@ public class Confidence: ConfidenceEventSender {
     */
     public func isStorageEmpty() -> Bool {
         return storage.isEmpty()
+    }
+
+    /**
+    Checks the stored resolution without activating it. Storage read errors are propagated.
+    */
+    public func getStorageStatus(check: ResolveStorageCheck) throws -> ResolveStorageStatus {
+        let resolution = try storage.load(defaultValue: FlagResolution.EMPTY)
+        return check.check(metadata: ResolveStorageMetadata(
+            isEmpty: resolution == FlagResolution.EMPTY,
+            lastFetchedAt: resolution.lastFetchedAt,
+            context: resolution.context
+        ))
     }
 
     /**

--- a/Sources/Confidence/FlagEvaluation.swift
+++ b/Sources/Confidence/FlagEvaluation.swift
@@ -22,6 +22,7 @@ struct FlagResolution: Encodable, Decodable, Equatable {
     let context: ConfidenceStruct
     let flags: [ResolvedValue]
     let resolveToken: String
+    var lastFetchedAt: Date?
     static let EMPTY = FlagResolution(context: [:], flags: [], resolveToken: "")
 }
 

--- a/Sources/Confidence/ResolveStorageStatus.swift
+++ b/Sources/Confidence/ResolveStorageStatus.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+/// The status of the flag resolution on disk according to a storage check.
+public enum ResolveStorageStatus: Equatable {
+    case empty
+    case stale(lastFetchedAt: Date?)
+    case fresh(lastFetchedAt: Date?)
+}
+
+/// Metadata for the stored resolution, independent of the currently activated values.
+public struct ResolveStorageMetadata {
+    public let isEmpty: Bool
+    public let lastFetchedAt: Date?
+    public let context: ConfidenceStruct
+
+    public init(isEmpty: Bool, lastFetchedAt: Date?, context: ConfidenceStruct) {
+        self.isEmpty = isEmpty
+        self.lastFetchedAt = lastFetchedAt
+        self.context = context
+    }
+}
+
+public protocol ResolveStorageCheck {
+    func check(metadata: ResolveStorageMetadata) -> ResolveStorageStatus
+}
+
+/// Treats unknown fetch times and ages at or beyond `maxAge` as stale.
+public struct MaxAgeStorageCheck: ResolveStorageCheck {
+    public let maxAge: TimeInterval
+    private let now: () -> Date
+
+    /// - Parameter maxAge: A positive, finite maximum age in seconds.
+    public init(maxAge: TimeInterval) {
+        self.init(maxAge: maxAge, now: Date.init)
+    }
+
+    internal init(maxAge: TimeInterval, now: @escaping () -> Date) {
+        precondition(maxAge > 0 && maxAge.isFinite, "maxAge must be positive and finite")
+        self.maxAge = maxAge
+        self.now = now
+    }
+
+    public func check(metadata: ResolveStorageMetadata) -> ResolveStorageStatus {
+        if metadata.isEmpty {
+            return .empty
+        }
+        guard let fetchedAt = metadata.lastFetchedAt else {
+            return .stale(lastFetchedAt: nil)
+        }
+        return now().timeIntervalSince(fetchedAt) >= maxAge
+            ? .stale(lastFetchedAt: fetchedAt)
+            : .fresh(lastFetchedAt: fetchedAt)
+    }
+}

--- a/Tests/ConfidenceTests/DefaultStorageTest.swift
+++ b/Tests/ConfidenceTests/DefaultStorageTest.swift
@@ -34,6 +34,21 @@ class DefaultStorageTest: XCTestCase {
         XCTAssertEqual(restoredValue, value)
     }
 
+    func testResolveTimestampPersistsWithResolution() throws {
+        let resolution = FlagResolution(
+            context: ["targeting_key": .init(string: "user")],
+            flags: [],
+            resolveToken: "token",
+            lastFetchedAt: Date(timeIntervalSince1970: 1234)
+        )
+        try storage.save(data: resolution)
+
+        let reopened = DefaultStorage(filePath: "resolver.cache")
+        XCTAssertEqual(try reopened.load(defaultValue: FlagResolution.EMPTY), resolution)
+        try reopened.clear()
+        XCTAssertNil(try reopened.load(defaultValue: FlagResolution.EMPTY).lastFetchedAt)
+    }
+
     func testResolvedValueShouldApplyBackwardCompatibility() throws {
         struct LegacyResolvedValue: Codable, Equatable {
             var variant: String?

--- a/Tests/ConfidenceTests/ResolveStorageStatusTests.swift
+++ b/Tests/ConfidenceTests/ResolveStorageStatusTests.swift
@@ -1,0 +1,106 @@
+import Foundation
+import XCTest
+
+@testable import Confidence
+
+class ResolveStorageStatusTests: XCTestCase {
+    func testMaxAgeBoundaries() {
+        let now = Date(timeIntervalSince1970: 10_000)
+        let check = MaxAgeStorageCheck(maxAge: 100) { now }
+        XCTAssertEqual(check.check(metadata: metadata(isEmpty: true)), .empty)
+        XCTAssertEqual(check.check(metadata: metadata()), .stale(lastFetchedAt: nil))
+        for age in [99.0, 100.0, 101.0, -1.0] {
+            let fetchedAt = now.addingTimeInterval(-age)
+            XCTAssertEqual(
+                check.check(metadata: metadata(lastFetchedAt: fetchedAt)),
+                age >= 100 ? .stale(lastFetchedAt: fetchedAt) : .fresh(lastFetchedAt: fetchedAt)
+            )
+        }
+    }
+
+    func testLegacyAndFutureCacheFields() throws {
+        let data = Data("""
+        {"context":{},"flags":[],"resolveToken":"token","futureField":true}
+        """.utf8)
+        let resolution = try JSONDecoder().decode(FlagResolution.self, from: data)
+        XCTAssertNil(resolution.lastFetchedAt)
+        let storage = try StorageMock(data: resolution)
+        let confidence = makeConfidence(storage: storage)
+        defer { confidence.stop() }
+        XCTAssertEqual(
+            try confidence.getStorageStatus(check: MaxAgeStorageCheck(maxAge: 100)),
+            .stale(lastFetchedAt: nil)
+        )
+    }
+
+    func testFetchPersistsMetadataWithoutActivationAndFailurePreservesIt() async throws {
+        let storage = StorageMock()
+        let resolver = StatusResolver()
+        let confidence = makeConfidence(storage: storage, resolver: resolver)
+        defer { confidence.stop() }
+        let check = MaxAgeStorageCheck(maxAge: 100)
+        XCTAssertEqual(try confidence.getStorageStatus(check: check), .empty)
+
+        let before = Date()
+        await confidence.asyncFetch()
+        let saved = try storage.load(defaultValue: FlagResolution.EMPTY)
+        let fetchedAt = try XCTUnwrap(saved.lastFetchedAt)
+        XCTAssertGreaterThanOrEqual(fetchedAt, before)
+        XCTAssertLessThanOrEqual(fetchedAt, Date())
+        XCTAssertEqual(saved.context, confidence.getContext())
+        XCTAssertEqual(try confidence.getStorageStatus(check: check), .fresh(lastFetchedAt: fetchedAt))
+
+        let recreated = makeConfidence(storage: storage)
+        defer { recreated.stop() }
+        XCTAssertEqual(try recreated.getStorageStatus(check: check), .fresh(lastFetchedAt: fetchedAt))
+        XCTAssertEqual(try recreated.getStorageStatus(check: ContextCheck()), .fresh(lastFetchedAt: fetchedAt))
+
+        resolver.shouldFail = true
+        await confidence.asyncFetch()
+        XCTAssertEqual(try storage.load(defaultValue: FlagResolution.EMPTY), saved)
+        try storage.clear()
+        XCTAssertEqual(try confidence.getStorageStatus(check: check), .empty)
+    }
+
+    func testCorruptStorageThrows() throws {
+        let storage = StorageMock()
+        storage.data = "invalid json"
+        let confidence = makeConfidence(storage: storage)
+        defer { confidence.stop() }
+        XCTAssertThrowsError(try confidence.getStorageStatus(check: MaxAgeStorageCheck(maxAge: 100)))
+    }
+
+    private func metadata(isEmpty: Bool = false, lastFetchedAt: Date? = nil) -> ResolveStorageMetadata {
+        ResolveStorageMetadata(isEmpty: isEmpty, lastFetchedAt: lastFetchedAt, context: [:])
+    }
+
+    private func makeConfidence(
+        storage: Storage,
+        resolver: ConfidenceResolveClient = StatusResolver()
+    ) -> Confidence {
+        Confidence.Builder(clientSecret: "", loggerLevel: .NONE)
+            .withStorage(storage: storage)
+            .withFlagResolverClient(flagResolver: resolver)
+            .withContext(initialContext: ["targeting_key": .init(string: "user")])
+            .build()
+    }
+}
+
+private struct ContextCheck: ResolveStorageCheck {
+    func check(metadata: ResolveStorageMetadata) -> ResolveStorageStatus {
+        XCTAssertEqual(metadata.context["targeting_key"], .init(string: "user"))
+        XCTAssertFalse(metadata.isEmpty)
+        return .fresh(lastFetchedAt: metadata.lastFetchedAt)
+    }
+}
+
+private class StatusResolver: ConfidenceResolveClient {
+    var shouldFail = false
+
+    func resolve(ctx: ConfidenceStruct) async throws -> ResolvesResult {
+        if shouldFail {
+            throw HttpClientError.invalidResponse
+        }
+        return ResolvesResult(resolvedValues: [], resolveToken: "token")
+    }
+}

--- a/api/Confidence_public_api.json
+++ b/api/Confidence_public_api.json
@@ -23,6 +23,10 @@
         "declaration": "public func isStorageEmpty() -> Bool"
       },
       {
+        "name": "getStorageStatus(check:)",
+        "declaration": "public func getStorageStatus(check: ResolveStorageCheck) throws -> ResolveStorageStatus"
+      },
+      {
         "name": "getEvaluation(key:defaultValue:)",
         "declaration": "public func getEvaluation<T>(key: String, defaultValue: T) -> Evaluation<T>"
       },
@@ -286,6 +290,28 @@
       {
         "name": "==(_:_:)",
         "declaration": "public static func == (lhs: ConfidenceValue, rhs: ConfidenceValue) -> Bool"
+      }
+    ]
+  },
+  {
+    "className": "ResolveStorageMetadata",
+    "apiFunctions": [
+      {
+        "name": "init(isEmpty:lastFetchedAt:context:)",
+        "declaration": "public init(isEmpty: Bool, lastFetchedAt: Date?, context: ConfidenceStruct)"
+      }
+    ]
+  },
+  {
+    "className": "MaxAgeStorageCheck",
+    "apiFunctions": [
+      {
+        "name": "init(maxAge:)",
+        "declaration": "public init(maxAge: TimeInterval)"
+      },
+      {
+        "name": "check(metadata:)",
+        "declaration": "public func check(metadata: ResolveStorageMetadata) -> ResolveStorageStatus"
       }
     ]
   }


### PR DESCRIPTION
Applications can now choose an initialization strategy based on cached resolution age, using empty/fresh/stale status or custom checks that inspect the stored context. Mirrors https://github.com/spotify/confidence-sdk-android/pull/261.

Successful fetches persist a timestamp atomically with the resolution. Legacy caches with no timestamp report stale; failed fetches preserve the previous timestamp. Includes usage examples and the public API snapshot.

Validation: 244 package tests and 201 iOS tests passed; SwiftLint passed. watchOS verification was blocked by the missing Xcode platform.
